### PR TITLE
Switching queue resource from azurerm to azapi

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -352,12 +352,17 @@ resource "azurerm_storage_account_customer_managed_key" "this" {
   }
 }
 
-resource "azurerm_storage_queue" "this" {
+resource "azapi_resource" "queues" {
   for_each = var.queues
 
-  name                 = each.value.name
-  storage_account_name = azurerm_storage_account.this.name
-  metadata             = each.value.metadata
+  type = "Microsoft.Storage/storageAccounts/queueServices/queues@2021-02-01"
+  body = jsonencode({
+    properties = {
+      metadata = each.value.metadata
+    }
+  })
+  name      = each.value.name
+  parent_id = "${azurerm_storage_account.this.id}/queueServices/default"
 
   dynamic "timeouts" {
     for_each = each.value.timeouts == null ? [] : [each.value.timeouts]

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,12 +35,12 @@ output "private_endpoints" {
 output "queues" {
   description = "Map of storage queues that are created."
   value = {
-    for name, queue in azurerm_storage_queue.this :
+    for name, queue in azapi_resource.queues :
     name => {
       id       = queue.id
       name     = queue.name
-      name     = queue.storage_account_name
-      metadata = queue.metadata
+      name     = azurerm_storage_account.this.name
+      metadata = jsondecode(queue.body).properties.metadata
     }
   }
 }


### PR DESCRIPTION
## Describe your changes
Switching Azure storage queue from azurerm_storage_queue to azapi_resource as the former results in 403-AuthorizationFailure

## Issue number

#44 

## Checklist before requesting a review
- [ ] The pr title can be used to describe what this pr did in `CHANGELOG.md` file
- [ ] I have executed pre-commit on my machine
- [ ] I have passed pr-check on my machine

Thanks for your cooperation!

