### PR TITLE
fix provider version for azapi

### DIFF
--- a/locals.version.tf.json
+++ b/locals.version.tf.json
@@ -1,1 +1,1 @@
-{"locals":{"module_version":"0.1.1"}}
+{"locals":{"module_version":"0.1.2"}}

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "1.9.0, < 2.0.0"
+      version = ">= 1.9.0, < 2.0.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
This is a simple fix to correct the provider version for azapi - it is missing ">=".  

This blocks the usage of this module with others, and is not the standard approach (as is self-evident from the other provider version blocks).