### PR TITLE
Add main.deprecated.tf to avoid configuration Drift on network_rules

### DIFF
--- a/main.deprecated.tf
+++ b/main.deprecated.tf
@@ -1,6 +1,6 @@
 removed {
   from = azurerm_storage_account_network_rules.this
   lifecycle {
-    detroy = false
+    destroy = false
   }
 }

--- a/main.deprecated.tf
+++ b/main.deprecated.tf
@@ -1,0 +1,6 @@
+removed {
+  from = azurerm_storage_account_network_rules.this
+  lifecycle {
+    detroy = false
+  }
+}


### PR DESCRIPTION
 Add main.deprecated.tf to avoid configuration Drift on `azurerm_storage_account_network_rules.this`
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Closes #147 
## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
