### PR TITLE
https://github.com/Azure/terraform-azurerm-avm-res-storage-storageaccount/issues/188

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ output "containers" {
     name => {
       id            = container.id
       name          = container.name
-      public_access = container.body.properties.publicAccess
+      public_access = jsondecode(container.body).properties.publicAccess
     }
   }
 }


### PR DESCRIPTION
To fix error 
│ Error: Unsupported attribute
│
│   on .terraform/modules/storage_account/terraform-azurerm-avm-res-storage-storageaccount-main/outputs.tf line 8, in output "containers":
│    8:       public_access = container.body.properties.publicAccess
│     ├────────────────
│     │ container.body is "{\"properties\":{\"immutableStorageWithVersioning\":null,\"metadata\":{},\"publicAccess\":\"container\"}}"
│
│ Can't access attributes on a primitive-typed value (string).

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [ ] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
