### PR TITLE
fix: enable diagnostic settings for storage and partner

### DIFF
--- a/main.diagnostics.tf
+++ b/main.diagnostics.tf
@@ -8,6 +8,8 @@ resource "azurerm_monitor_diagnostic_setting" "storage_account" {
   eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
   eventhub_name                  = each.value.event_hub_name
   log_analytics_workspace_id     = each.value.workspace_resource_id
+  storage_account_id             = each.value.storage_account_resource_id
+  partner_solution_id            = each.value.marketplace_partner_resource_id
 
   dynamic "metric" {
     for_each = each.value.metric_categories
@@ -26,6 +28,8 @@ resource "azurerm_monitor_diagnostic_setting" "blob" {
   eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
   eventhub_name                  = each.value.event_hub_name
   log_analytics_workspace_id     = each.value.workspace_resource_id
+  storage_account_id             = each.value.storage_account_resource_id
+  partner_solution_id            = each.value.marketplace_partner_resource_id
 
   dynamic "enabled_log" {
     for_each = each.value.log_categories
@@ -52,6 +56,8 @@ resource "azurerm_monitor_diagnostic_setting" "queue" {
   eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
   eventhub_name                  = each.value.event_hub_name
   log_analytics_workspace_id     = each.value.workspace_resource_id
+  storage_account_id             = each.value.storage_account_resource_id
+  partner_solution_id            = each.value.marketplace_partner_resource_id
 
   dynamic "enabled_log" {
     for_each = each.value.log_categories
@@ -77,6 +83,8 @@ resource "azurerm_monitor_diagnostic_setting" "table" {
   eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
   eventhub_name                  = each.value.event_hub_name
   log_analytics_workspace_id     = each.value.workspace_resource_id
+  storage_account_id             = each.value.storage_account_resource_id
+  partner_solution_id            = each.value.marketplace_partner_resource_id
 
   dynamic "enabled_log" {
     for_each = each.value.log_categories
@@ -102,6 +110,8 @@ resource "azurerm_monitor_diagnostic_setting" "azure_file" {
   eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
   eventhub_name                  = each.value.event_hub_name
   log_analytics_workspace_id     = each.value.workspace_resource_id
+  storage_account_id             = each.value.storage_account_resource_id
+  partner_solution_id            = each.value.marketplace_partner_resource_id
 
   dynamic "enabled_log" {
     for_each = each.value.log_categories


### PR DESCRIPTION
storage and partner integration was not enabled since the input vars was not used

## Description
Storage and partner integration for diagnostic settings was not applied to the azurerm resource, even though the input variables to the module indicated that it was supported

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
