### PR TITLE
Proposal: Add Support for azurerm_storage_share_directory in Azure Verified Module (AVM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following resources are used by this module:
 - [azurerm_storage_account_local_user.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account_local_user) (resource)
 - [azurerm_storage_data_lake_gen2_filesystem.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_data_lake_gen2_filesystem) (resource)
 - [azurerm_storage_management_policy.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_management_policy) (resource)
+- [azurerm_storage_share_directory.directories](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_share_directory) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/resources/telemetry) (resource)
 - [random_uuid.telemetry](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) (resource)
 - [azurerm_client_config.telemetry](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
@@ -1174,6 +1175,11 @@ Description:  - `access_tier` - (Optional) The access tier of the File Share. Po
  - `read` - (Defaults to 5 minutes) Used when retrieving the Storage Share.
  - `update` - (Defaults to 30 minutes) Used when updating the Storage Share.
 
+ ---
+ `directories` block supports the following:
+ - `name` - The name (or path) of the Directory that should be created within this File Share. Changing this forces a new resource to be created.
+ - `metadata` - A mapping of metadata to assign to this Directory.
+
 Supply role assignments in the same way as for `var.role_assignments`.
 
 Type:
@@ -1209,6 +1215,10 @@ map(object({
       read   = optional(string)
       update = optional(string)
     }))
+    directories = optional(list(object({
+      name     = string
+      metadata = optional(map(string))
+    })), [])
   }))
 ```
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -243,6 +243,12 @@ module "this" {
         key1 = "value1"
         key2 = "value2"
       }
+      directories = [
+        {
+          name     = "exampleShare"
+          metadata = { key1 = "value1" }
+        },
+      ]
     }
   }
 }

--- a/variables.share.tf
+++ b/variables.share.tf
@@ -29,6 +29,10 @@ variable "shares" {
       read   = optional(string)
       update = optional(string)
     }))
+    directories = optional(list(object({
+      name     = string
+      metadata = optional(map(string))
+    })), [])
   }))
   default     = {}
   description = <<-EOT
@@ -54,6 +58,11 @@ variable "shares" {
  - `delete` - (Defaults to 30 minutes) Used when deleting the Storage Share.
  - `read` - (Defaults to 5 minutes) Used when retrieving the Storage Share.
  - `update` - (Defaults to 30 minutes) Used when updating the Storage Share.
+
+ ---
+ `directories` block supports the following:
+ - `name` - The name (or path) of the Directory that should be created within this File Share. Changing this forces a new resource to be created.
+ - `metadata` - A mapping of metadata to assign to this Directory.
 
 Supply role assignments in the same way as for `var.role_assignments`.
 


### PR DESCRIPTION
## Description

Currently, the Azure Verified Module (AVM) for Storage Accounts does not provide a way to create directories within an Azure Storage File Share. While the module supports creating file shares, it lacks native functionality to define and manage directories within these shares.

I know that you had ruled out such functionality for the time being with [Issue #132](https://github.com/Azure/terraform-azurerm-avm-res-storage-storageaccount/issues/132).
Nevertheless, I would like to get feedback for my first PR on GitHub.

- Added the `azurerm_storage_share_directory` resource to `main.shares.tf`
- Added `directories` block inside of `var.shares`
- Added example to `examples/default/main.tf`
- Updated `README.md`

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks