### PR TITLE
fix(TEP-411): Add permanent_delete_enabled in blob_properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Description: - `change_feed_enabled` - (Optional) Is the blob service properties
 ---
 `delete_retention_policy` block supports the following:
 - `days` - (Optional) Specifies the number of days that the blob should be retained, between `1` and `365` days. Defaults to `7`.
+- `permanent_delete_enabled` - (Optional) Specifies whether permanent delete is enabled. Defaults to `false`.
 
 ---
 `diagnostic_settings` block supports the following:
@@ -232,8 +233,9 @@ object({
     versioning_enabled            = optional(bool, true)
     container_delete_retention_policy = optional(object({
       days = optional(number, 7)
+      permanent_delete_enabled = optional(bool, false)
 
-    }), { days = 7 })
+    }), { days = 7, permanent_delete_enabled = false })
 
     cors_rule = optional(list(object({
       allowed_headers    = list(string)

--- a/main.tf
+++ b/main.tf
@@ -85,7 +85,8 @@ resource "azurerm_storage_account" "this" {
         ]
 
         content {
-          days = delete_retention_policy.value.days
+          days                     = delete_retention_policy.value.days
+          permanent_delete_enabled = delete_retention_policy.value.permanent_delete_enabled
         }
       }
       dynamic "restore_policy" {

--- a/variables.container.tf
+++ b/variables.container.tf
@@ -18,8 +18,9 @@ variable "blob_properties" {
       max_age_in_seconds = number
     })))
     delete_retention_policy = optional(object({
-      days = optional(number, 7)
-    }), { days = 7 })
+      days                     = optional(number, 7)
+      permanent_delete_enabled = optional(bool, false)
+    }), { days = 7, permanent_delete_enabled = false })
     diagnostic_settings = optional(map(object({
       name                                     = optional(string, null)
       log_categories                           = optional(set(string), [])
@@ -59,6 +60,7 @@ variable "blob_properties" {
  ---
  `delete_retention_policy` block supports the following:
  - `days` - (Optional) Specifies the number of days that the blob should be retained, between `1` and `365` days. Defaults to `7`.
+ - `permanent_delete_enabled` - (Optional) Specifies whether permanent delete is enabled. Defaults to `false`.
 
  ---
  `diagnostic_settings` block supports the following:


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Adds missing `permanent_delete_enabled` attribute in `delete_retention_policy ` block in `blob_properties`.
It is present in the earliest supported version of this module `3.116.0` and in the latest AzureRM provider version. See [here](https://registry.terraform.io/providers/hashicorp/azurerm/3.116.0/docs/resources/storage_account#permanent_delete_enabled-1).

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
