### PR TITLE
Add principal_type assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ map(object({
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, null)
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)
@@ -979,6 +980,7 @@ map(object({
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, null)
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)
@@ -1198,6 +1200,7 @@ map(object({
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, null)
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)
@@ -1498,6 +1501,7 @@ map(object({
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, null)
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)

--- a/main.containers.tf
+++ b/main.containers.tf
@@ -33,6 +33,7 @@ resource "azurerm_role_assignment" "containers" {
   for_each = local.containers_role_assignments
 
   principal_id                           = each.value.role_assignment.principal_id
+  principal_type                         = each.value.role_assignment.principal_type
   scope                                  = azapi_resource.containers[each.value.container_key].id
   condition                              = each.value.role_assignment.condition
   condition_version                      = each.value.role_assignment.condition_version

--- a/main.containers.tf
+++ b/main.containers.tf
@@ -33,11 +33,11 @@ resource "azurerm_role_assignment" "containers" {
   for_each = local.containers_role_assignments
 
   principal_id                           = each.value.role_assignment.principal_id
-  principal_type                         = each.value.role_assignment.principal_type
   scope                                  = azapi_resource.containers[each.value.container_key].id
   condition                              = each.value.role_assignment.condition
   condition_version                      = each.value.role_assignment.condition_version
   delegated_managed_identity_resource_id = each.value.role_assignment.delegated_managed_identity_resource_id
+  principal_type                         = each.value.role_assignment.principal_type
   role_definition_id                     = strcontains(lower(each.value.role_assignment.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? each.value.role_assignment.role_definition_id_or_name : null
   role_definition_name                   = strcontains(lower(each.value.role_assignment.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? null : each.value.role_assignment.role_definition_id_or_name
   skip_service_principal_aad_check       = each.value.role_assignment.skip_service_principal_aad_check

--- a/main.queues.tf
+++ b/main.queues.tf
@@ -33,6 +33,7 @@ resource "azurerm_role_assignment" "queues" {
   for_each = local.queues_role_assignments
 
   principal_id                           = each.value.role_assignment.principal_id
+  principal_type                         = each.value.role_assignment.principal_type
   scope                                  = "${azurerm_storage_account.this.id}/queueServices/default/queues/${azapi_resource.queue[each.value.queue_key].name}"
   condition                              = each.value.role_assignment.condition
   condition_version                      = each.value.role_assignment.condition_version

--- a/main.queues.tf
+++ b/main.queues.tf
@@ -33,11 +33,11 @@ resource "azurerm_role_assignment" "queues" {
   for_each = local.queues_role_assignments
 
   principal_id                           = each.value.role_assignment.principal_id
-  principal_type                         = each.value.role_assignment.principal_type
   scope                                  = "${azurerm_storage_account.this.id}/queueServices/default/queues/${azapi_resource.queue[each.value.queue_key].name}"
   condition                              = each.value.role_assignment.condition
   condition_version                      = each.value.role_assignment.condition_version
   delegated_managed_identity_resource_id = each.value.role_assignment.delegated_managed_identity_resource_id
+  principal_type                         = each.value.role_assignment.principal_type
   role_definition_id                     = strcontains(lower(each.value.role_assignment.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? each.value.role_assignment.role_definition_id_or_name : null
   role_definition_name                   = strcontains(lower(each.value.role_assignment.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? null : each.value.role_assignment.role_definition_id_or_name
   skip_service_principal_aad_check       = each.value.role_assignment.skip_service_principal_aad_check

--- a/main.shares.tf
+++ b/main.shares.tf
@@ -42,11 +42,11 @@ resource "azurerm_role_assignment" "shares" {
   for_each = local.shares_role_assignments
 
   principal_id                           = each.value.role_assignment.principal_id
-  principal_type                         = each.value.role_assignment.principal_type
   scope                                  = "${azurerm_storage_account.this.id}/fileServices/default/shares/${azapi_resource.share[each.value.share_key].name}"
   condition                              = each.value.role_assignment.condition
   condition_version                      = each.value.role_assignment.condition_version
   delegated_managed_identity_resource_id = each.value.role_assignment.delegated_managed_identity_resource_id
+  principal_type                         = each.value.role_assignment.principal_type
   role_definition_id                     = strcontains(lower(each.value.role_assignment.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? each.value.role_assignment.role_definition_id_or_name : null
   role_definition_name                   = strcontains(lower(each.value.role_assignment.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? null : each.value.role_assignment.role_definition_id_or_name
   skip_service_principal_aad_check       = each.value.role_assignment.skip_service_principal_aad_check

--- a/main.shares.tf
+++ b/main.shares.tf
@@ -42,6 +42,7 @@ resource "azurerm_role_assignment" "shares" {
   for_each = local.shares_role_assignments
 
   principal_id                           = each.value.role_assignment.principal_id
+  principal_type                         = each.value.role_assignment.principal_type
   scope                                  = "${azurerm_storage_account.this.id}/fileServices/default/shares/${azapi_resource.share[each.value.share_key].name}"
   condition                              = each.value.role_assignment.condition
   condition_version                      = each.value.role_assignment.condition_version

--- a/main.tables.tf
+++ b/main.tables.tf
@@ -30,13 +30,13 @@ resource "azapi_resource" "table" {
 resource "azurerm_role_assignment" "tables" {
   for_each = local.tables_role_assignments
 
-  principal_id   = each.value.role_assignment.principal_id
-  principal_type = each.value.role_assignment.principal_type
+  principal_id = each.value.role_assignment.principal_id
   # the resource manager id is not exposed directly by the AzureRM provider - https://github.com/hashicorp/terraform-provider-azurerm/issues/21525
   scope                                  = "${azurerm_storage_account.this.id}/tableServices/default/tables/${azapi_resource.table[each.value.table_key].name}"
   condition                              = each.value.role_assignment.condition
   condition_version                      = each.value.role_assignment.condition_version
   delegated_managed_identity_resource_id = each.value.role_assignment.delegated_managed_identity_resource_id
+  principal_type                         = each.value.role_assignment.principal_type
   role_definition_id                     = strcontains(lower(each.value.role_assignment.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? each.value.role_assignment.role_definition_id_or_name : null
   role_definition_name                   = strcontains(lower(each.value.role_assignment.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? null : each.value.role_assignment.role_definition_id_or_name
   skip_service_principal_aad_check       = each.value.role_assignment.skip_service_principal_aad_check

--- a/main.tables.tf
+++ b/main.tables.tf
@@ -30,7 +30,8 @@ resource "azapi_resource" "table" {
 resource "azurerm_role_assignment" "tables" {
   for_each = local.tables_role_assignments
 
-  principal_id = each.value.role_assignment.principal_id
+  principal_id   = each.value.role_assignment.principal_id
+  principal_type = each.value.role_assignment.principal_type
   # the resource manager id is not exposed directly by the AzureRM provider - https://github.com/hashicorp/terraform-provider-azurerm/issues/21525
   scope                                  = "${azurerm_storage_account.this.id}/tableServices/default/tables/${azapi_resource.table[each.value.table_key].name}"
   condition                              = each.value.role_assignment.condition

--- a/main.tf
+++ b/main.tf
@@ -282,11 +282,11 @@ resource "azurerm_role_assignment" "storage_account" {
   for_each = var.role_assignments
 
   principal_id                           = each.value.principal_id
-  principal_type                         = each.value.principal_type
   scope                                  = azurerm_storage_account.this.id
   condition                              = each.value.condition
   condition_version                      = each.value.condition_version
   delegated_managed_identity_resource_id = each.value.delegated_managed_identity_resource_id
+  principal_type                         = each.value.principal_type
   role_definition_id                     = strcontains(lower(each.value.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? each.value.role_definition_id_or_name : null
   role_definition_name                   = strcontains(lower(each.value.role_definition_id_or_name), lower(local.role_definition_resource_substring)) ? null : each.value.role_definition_id_or_name
   skip_service_principal_aad_check       = each.value.skip_service_principal_aad_check

--- a/main.tf
+++ b/main.tf
@@ -282,6 +282,7 @@ resource "azurerm_role_assignment" "storage_account" {
   for_each = var.role_assignments
 
   principal_id                           = each.value.principal_id
+  principal_type                         = each.value.principal_type
   scope                                  = azurerm_storage_account.this.id
   condition                              = each.value.condition
   condition_version                      = each.value.condition_version

--- a/variables.container.tf
+++ b/variables.container.tf
@@ -95,6 +95,7 @@ variable "containers" {
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, null)
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)

--- a/variables.queue.tf
+++ b/variables.queue.tf
@@ -99,6 +99,7 @@ variable "queues" {
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, null)
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)

--- a/variables.share.tf
+++ b/variables.share.tf
@@ -123,6 +123,7 @@ variable "shares" {
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, null)
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)

--- a/variables.table.tf
+++ b/variables.table.tf
@@ -19,6 +19,7 @@ variable "tables" {
     role_assignments = optional(map(object({
       role_definition_id_or_name             = string
       principal_id                           = string
+      principal_type                         = optional(string, null)
       description                            = optional(string, null)
       skip_service_principal_aad_check       = optional(bool, false)
       condition                              = optional(string, null)


### PR DESCRIPTION
## Description

This pull request introduces the principal type in role assignment. Even if this property is optional in role assignment, it may be possible to set the value when required. When using Azure Policy to control allowed principal types for instance, this property must be set, otherwise, Azure policy analysis the role assignment request body which fails, because no principal type is set when left empty.

Fixes #264
Closes #264 

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
