### PR TITLE
Fix provisioned_billing_model_version to support Terraform v1.11

### DIFF
--- a/variables.storageaccount.tf
+++ b/variables.storageaccount.tf
@@ -226,7 +226,7 @@ variable "provisioned_billing_model_version" {
   description = "(Optional) Specifies the version of the provisioned billing model (e.g. when account_kind = \"FileStorage\" for Storage File). Possible value is V2. Changing this forces a new resource to be created."
 
   validation {
-    condition     = var.provisioned_billing_model_version == null || contains(["V2"], var.provisioned_billing_model_version)
+    condition     = var.provisioned_billing_model_version == null || var.provisioned_billing_model_version == "V2"
     error_message = "Invalid value for provisioned_billing_model_version. Valid options are `V2`."
   }
 }


### PR DESCRIPTION
This pull request makes a minor update to the validation logic for the `provisioned_billing_model_version` variable in the Terraform configuration. The change simplifies the condition by directly checking if the value is `"V2"` instead of using a list.

- Simplified the validation condition for the `provisioned_billing_model_version` variable in `variables.storageaccount.tf` by replacing the `contains` function with a direct comparison to `"V2"`.
 - This fix will support Terraform V1.11.0 and below `OR` Operator bug.

Fixes #299 
Closes #299 

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
