### PR TITLE
Support categories and category groups for storage account diagnostic settings

### DIFF
--- a/main.diagnostics.tf
+++ b/main.diagnostics.tf
@@ -8,7 +8,7 @@ resource "azurerm_monitor_diagnostic_setting" "storage_account" {
   eventhub_authorization_rule_id = each.value.event_hub_authorization_rule_resource_id
   eventhub_name                  = each.value.event_hub_name
   log_analytics_workspace_id     = each.value.workspace_resource_id
-  
+
   dynamic "enabled_log" {
     for_each = try(each.value.log_categories != null ? each.value.log_categories : [], [])
 


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

Adding categories/groups as an option for base storage account diagnostic settings. Previously only metrics were supported, but the documentation says it should support category groups:

<img width="956" height="610" alt="image" src="https://github.com/user-attachments/assets/0c135112-a77c-4a94-947f-6b6d9b92c620" />


Fixes #309

I've been implementing this for my own storage account and did a plan, but not a full apply to test this. As I was just adding options that exist in other diagnostic settings types I didn't think that it needs to apply the entire way. I am open to trying this though.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
