### PR TITLE
fix: set public_network_access_enabled to false in private endpoint examples

### DIFF
--- a/examples/private-endpoint-manage_dns_zone_group/README.md
+++ b/examples/private-endpoint-manage_dns_zone_group/README.md
@@ -196,7 +196,7 @@ module "this" {
   }
   #Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy.
   private_endpoints_manage_dns_zone_group = true
-  public_network_access_enabled           = true
+  public_network_access_enabled           = false
   queues = {
     queue0 = {
       name = "queue-${random_string.this.result}-0"

--- a/examples/private-endpoint-manage_dns_zone_group/main.tf
+++ b/examples/private-endpoint-manage_dns_zone_group/main.tf
@@ -189,7 +189,7 @@ module "this" {
   }
   #Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy.
   private_endpoints_manage_dns_zone_group = true
-  public_network_access_enabled           = true
+  public_network_access_enabled           = false
   queues = {
     queue0 = {
       name = "queue-${random_string.this.result}-0"

--- a/examples/private-endpoint-static-ip/README.md
+++ b/examples/private-endpoint-static-ip/README.md
@@ -210,7 +210,7 @@ module "this" {
 
 
   }
-  public_network_access_enabled = true
+  public_network_access_enabled = false
   queues = {
     queue0 = {
       name = "queue-${random_string.this.result}-0"

--- a/examples/private-endpoint-static-ip/main.tf
+++ b/examples/private-endpoint-static-ip/main.tf
@@ -203,7 +203,7 @@ module "this" {
 
 
   }
-  public_network_access_enabled = true
+  public_network_access_enabled = false
   queues = {
     queue0 = {
       name = "queue-${random_string.this.result}-0"

--- a/examples/private-endpoint-unmanage_dns_zone_group/README.md
+++ b/examples/private-endpoint-unmanage_dns_zone_group/README.md
@@ -196,7 +196,7 @@ module "this" {
   }
   #Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy.
   private_endpoints_manage_dns_zone_group = false
-  public_network_access_enabled           = true
+  public_network_access_enabled           = false
   queues = {
     queue0 = {
       name = "queue-${random_string.this.result}-0"

--- a/examples/private-endpoint-unmanage_dns_zone_group/main.tf
+++ b/examples/private-endpoint-unmanage_dns_zone_group/main.tf
@@ -189,7 +189,7 @@ module "this" {
   }
   #Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy.
   private_endpoints_manage_dns_zone_group = false
-  public_network_access_enabled           = true
+  public_network_access_enabled           = false
   queues = {
     queue0 = {
       name = "queue-${random_string.this.result}-0"


### PR DESCRIPTION
## Summary

The `private-endpoint-static-ip`, `private-endpoint-manage_dns_zone_group`, and `private-endpoint-unmanage_dns_zone_group` examples incorrectly set `public_network_access_enabled = true`. When using private endpoints, public network access should be disabled to secure the transportation layer.

## Changes

Changed `public_network_access_enabled` from `true` to `false` in three example files:
- `examples/private-endpoint-static-ip/main.tf`
- `examples/private-endpoint-manage_dns_zone_group/main.tf`
- `examples/private-endpoint-unmanage_dns_zone_group/main.tf`

The `private-endpoint-basic` example already correctly uses the default value (`false`).

## References

- Per [Azure Storage network security documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security-overview): "To permit traffic only from private links, you can block all access over the public endpoint."
- The module default for `public_network_access_enabled` is already `false` (`variables.storageaccount.tf` line 234-238). These examples were explicitly overriding the correct default.

> Note: The `network_rules` blocks in these examples are retained as-is. They only affect public endpoint traffic and have no effect when `public_network_access_enabled = false`, but removing them is a separate concern.

Fixes #327