### PR TITLE
fix: require AzAPI 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ This Terraform module is designed to create Azure Storage Accounts and its relat
 
 > **IMPORTANT** This module manages the Storage Account itself, plus its child containers, queues, tables, file shares, private endpoints and role assignments, through the AzAPI provider, which always authenticates with Microsoft Entra ID and never requires a Storage shared key. We recommend leaving `shared_access_key_enabled = false` (the module default) so that any data-plane access from your own code is also Entra-ID-authenticated. If you also use the [`azurerm` provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#storage_use_azuread) to manage Storage data-plane resources (for example `azurerm_storage_blob`), set `storage_use_azuread = true` in that provider block. Note that not every Storage service supports Microsoft Entra ID authentication; for those services you will need to enable shared-key access by setting `shared_access_key_enabled = true` on this module.
 
+## Upgrading
+
+This module requires AzAPI provider version 2.9.0 or later within the 2.x series (`>= 2.9.0, < 3.0.0`). When upgrading to a module release with this requirement, update any AzAPI constraint in your root module that excludes version 2.9.0, then refresh the provider selections recorded in your dependency lock file:
+
+```terraform
+terraform {
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.9"
+    }
+  }
+}
+```
+
+```shell
+terraform init -upgrade
+```
+
 <!-- markdownlint-disable MD033 -->
 ## Requirements
 
@@ -28,7 +47,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 - <a name="requirement_modtm"></a> [modtm](#requirement\_modtm) (~> 0.3)
 

--- a/_header.md
+++ b/_header.md
@@ -18,3 +18,22 @@ This Terraform module is designed to create Azure Storage Accounts and its relat
 * The module creates resources in the same region as the storage account.
 
 > **IMPORTANT** This module manages the Storage Account itself, plus its child containers, queues, tables, file shares, private endpoints and role assignments, through the AzAPI provider, which always authenticates with Microsoft Entra ID and never requires a Storage shared key. We recommend leaving `shared_access_key_enabled = false` (the module default) so that any data-plane access from your own code is also Entra-ID-authenticated. If you also use the [`azurerm` provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#storage_use_azuread) to manage Storage data-plane resources (for example `azurerm_storage_blob`), set `storage_use_azuread = true` in that provider block. Note that not every Storage service supports Microsoft Entra ID authentication; for those services you will need to enable shared-key access by setting `shared_access_key_enabled = true` on this module.
+
+## Upgrading
+
+This module requires AzAPI provider version 2.9.0 or later within the 2.x series (`>= 2.9.0, < 3.0.0`). When upgrading to a module release with this requirement, update any AzAPI constraint in your root module that excludes version 2.9.0, then refresh the provider selections recorded in your dependency lock file:
+
+```terraform
+terraform {
+  required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.9"
+    }
+  }
+}
+```
+
+```shell
+terraform init -upgrade
+```

--- a/modules/blob_service/README.md
+++ b/modules/blob_service/README.md
@@ -57,7 +57,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/blob_service/terraform.tf
+++ b/modules/blob_service/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/container/README.md
+++ b/modules/container/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/container/terraform.tf
+++ b/modules/container/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/data_lake_filesystem/README.md
+++ b/modules/data_lake_filesystem/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/data_lake_filesystem/terraform.tf
+++ b/modules/data_lake_filesystem/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/diagnostic_setting/README.md
+++ b/modules/diagnostic_setting/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/diagnostic_setting/terraform.tf
+++ b/modules/diagnostic_setting/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/file_service/README.md
+++ b/modules/file_service/README.md
@@ -47,7 +47,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/file_service/terraform.tf
+++ b/modules/file_service/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/local_user/README.md
+++ b/modules/local_user/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/local_user/terraform.tf
+++ b/modules/local_user/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/management_policy/README.md
+++ b/modules/management_policy/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/management_policy/terraform.tf
+++ b/modules/management_policy/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/private_endpoint/README.md
+++ b/modules/private_endpoint/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/private_endpoint/terraform.tf
+++ b/modules/private_endpoint/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/queue/README.md
+++ b/modules/queue/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/queue/terraform.tf
+++ b/modules/queue/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/queue_service/README.md
+++ b/modules/queue_service/README.md
@@ -45,7 +45,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/queue_service/terraform.tf
+++ b/modules/queue_service/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/role_assignments/README.md
+++ b/modules/role_assignments/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/role_assignments/terraform.tf
+++ b/modules/role_assignments/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/share/README.md
+++ b/modules/share/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/share/terraform.tf
+++ b/modules/share/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/static_website/README.md
+++ b/modules/static_website/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/static_website/terraform.tf
+++ b/modules/static_website/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/table/README.md
+++ b/modules/table/README.md
@@ -12,7 +12,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 ## Resources
 

--- a/modules/table/terraform.tf
+++ b/modules/table/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
   }
 }

--- a/modules/table_service/README.md
+++ b/modules/table_service/README.md
@@ -61,7 +61,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.10.0)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.8)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2.9)
 
 - <a name="requirement_time"></a> [time](#requirement\_time) (~> 0.13)
 

--- a/modules/table_service/terraform.tf
+++ b/modules/table_service/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
     time = {
       source  = "hashicorp/time"

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "~> 2.8"
+      version = "~> 2.9"
     }
     modtm = {
       source  = "Azure/modtm"


### PR DESCRIPTION
## Description

Raises the minimum supported AzAPI provider version from `~> 2.8` to `~> 2.9` in the root module and all independently consumable child modules. This matches the actual minimum required by `ignore_other_items_in_list`, which was introduced in AzAPI 2.9.0.

Regenerates the provider requirements in each README and adds consumer upgrade guidance to the root README.

### Upgrade guidance

When upgrading to the release containing this fix:

1. Update any root-module AzAPI constraint that excludes 2.9.0. The recommended constraint is `version = "~> 2.9"` (`>= 2.9.0, < 3.0.0`).
2. Run `terraform init -upgrade` so Terraform can replace an AzAPI 2.8.x selection in `.terraform.lock.hcl`.
3. Commit the resulting lock-file change and run `terraform plan` before applying.

The module configuration itself does not change resource arguments; this update corrects provider compatibility metadata.

Closes #360

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #360" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

Local `pr-check` initialized all examples successfully. Azure-authenticated plans that use the AzureRM provider could not run because this workstation's Azure CLI account was not present in the MSAL token cache; CI will run those authenticated checks.