### PR TITLE
fix: prevent diagnostic settings drift

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -286,7 +286,7 @@ module "this" {
         { category = "StorageDelete" },
       ]
       metrics = [
-        { category = "Transaction" },
+        { category = "AllMetrics" },
       ]
     }
   }
@@ -300,7 +300,7 @@ module "this" {
         { category_group = "audit" },
       ]
       metrics = [
-        { category = "Transaction" },
+        { category = "AllMetrics" },
       ]
     }
   }
@@ -315,7 +315,7 @@ module "this" {
         { category = "StorageDelete" },
       ]
       metrics = [
-        { category = "Transaction" },
+        { category = "AllMetrics" },
       ]
     }
   }
@@ -340,7 +340,7 @@ module "this" {
         { category = "StorageWrite" },
       ]
       metrics = [
-        { category = "Transaction" },
+        { category = "AllMetrics" },
       ]
     }
   }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -269,7 +269,7 @@ module "this" {
         { category = "StorageDelete" },
       ]
       metrics = [
-        { category = "Transaction" },
+        { category = "AllMetrics" },
       ]
     }
   }
@@ -283,7 +283,7 @@ module "this" {
         { category_group = "audit" },
       ]
       metrics = [
-        { category = "Transaction" },
+        { category = "AllMetrics" },
       ]
     }
   }
@@ -298,7 +298,7 @@ module "this" {
         { category = "StorageDelete" },
       ]
       metrics = [
-        { category = "Transaction" },
+        { category = "AllMetrics" },
       ]
     }
   }
@@ -323,7 +323,7 @@ module "this" {
         { category = "StorageWrite" },
       ]
       metrics = [
-        { category = "Transaction" },
+        { category = "AllMetrics" },
       ]
     }
   }

--- a/locals.diagnostics.tf
+++ b/locals.diagnostics.tf
@@ -1,0 +1,50 @@
+locals {
+  # Azure expands AllMetrics into concrete metric categories when diagnostic
+  # settings are read at Storage service scopes. Normalize before calling the
+  # generic diagnostic setting submodule to avoid a perpetual plan diff.
+  #
+  # Azure Files also exposes the SLI category. The other service scopes expose
+  # only Capacity and Transaction.
+  storage_service_metric_categories = {
+    blob  = toset(["Capacity", "Transaction"])
+    file  = toset(["Capacity", "SLI", "Transaction"])
+    queue = toset(["Capacity", "Transaction"])
+    table = toset(["Capacity", "Transaction"])
+  }
+  # The storage account scope returns AllMetrics unchanged, so only normalize
+  # the four service scopes whose read responses contain concrete categories.
+  storage_service_diagnostic_settings = {
+    blob  = var.diagnostic_settings_blob
+    file  = var.diagnostic_settings_file
+    queue = var.diagnostic_settings_queue
+    table = var.diagnostic_settings_table
+  }
+  storage_service_diagnostic_settings_normalized = {
+    for service_name, diagnostic_settings in local.storage_service_diagnostic_settings : service_name => {
+      for setting_name, setting in diagnostic_settings : setting_name => merge(setting, {
+        metrics = setunion(
+          # Preserve non-AllMetrics entries exactly as supplied. An explicitly
+          # configured concrete category takes precedence over one generated
+          # from AllMetrics, which also prevents duplicate category entries.
+          toset([
+            for metric in setting.metrics : metric
+            if metric.category != "AllMetrics"
+          ]),
+          toset(flatten([
+            for metric in setting.metrics : metric.category == "AllMetrics" ? [
+              for category in local.storage_service_metric_categories[service_name] : {
+                category         = category
+                enabled          = metric.enabled
+                retention_policy = metric.retention_policy
+              }
+              if !contains([
+                for explicit_metric in setting.metrics : explicit_metric.category
+                if explicit_metric.category != "AllMetrics"
+              ], category)
+            ] : []
+          ]))
+        )
+      })
+    }
+  }
+}

--- a/main.diagnostics.tf
+++ b/main.diagnostics.tf
@@ -13,7 +13,7 @@ module "diagnostic_setting_blob" {
   source = "./modules/diagnostic_setting"
 
   parent_id           = "${azapi_resource.this.id}/blobServices/default"
-  diagnostic_settings = var.diagnostic_settings_blob
+  diagnostic_settings = local.storage_service_diagnostic_settings_normalized.blob
   enable_telemetry    = var.enable_telemetry
   retry               = var.retry
   timeouts            = var.timeouts
@@ -24,7 +24,7 @@ module "diagnostic_setting_queue" {
   source = "./modules/diagnostic_setting"
 
   parent_id           = "${azapi_resource.this.id}/queueServices/default"
-  diagnostic_settings = var.diagnostic_settings_queue
+  diagnostic_settings = local.storage_service_diagnostic_settings_normalized.queue
   enable_telemetry    = var.enable_telemetry
   retry               = var.retry
   timeouts            = var.timeouts
@@ -35,7 +35,7 @@ module "diagnostic_setting_table" {
   source = "./modules/diagnostic_setting"
 
   parent_id           = "${azapi_resource.this.id}/tableServices/default"
-  diagnostic_settings = var.diagnostic_settings_table
+  diagnostic_settings = local.storage_service_diagnostic_settings_normalized.table
   enable_telemetry    = var.enable_telemetry
   retry               = var.retry
   timeouts            = var.timeouts
@@ -46,7 +46,7 @@ module "diagnostic_setting_file" {
   source = "./modules/diagnostic_setting"
 
   parent_id           = "${azapi_resource.this.id}/fileServices/default"
-  diagnostic_settings = var.diagnostic_settings_file
+  diagnostic_settings = local.storage_service_diagnostic_settings_normalized.file
   enable_telemetry    = var.enable_telemetry
   retry               = var.retry
   timeouts            = var.timeouts

--- a/tests/unit/diagnostic_settings.tftest.hcl
+++ b/tests/unit/diagnostic_settings.tftest.hcl
@@ -1,0 +1,190 @@
+# Unit tests for Storage service diagnostic metric normalization.
+mock_provider "azapi" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location                 = "eastus"
+  name                     = "stunittest001"
+  parent_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  diagnostic_settings_blob = {
+    normalized = {
+      name                  = "blob-diagnostic-setting"
+      workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.OperationalInsights/workspaces/law-unit-test"
+      metrics = [{
+        category = "AllMetrics"
+        enabled  = false
+        retention_policy = {
+          days    = 7
+          enabled = true
+        }
+      }]
+    }
+  }
+
+  diagnostic_settings_file = {
+    normalized = {
+      name                  = "file-diagnostic-setting"
+      workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.OperationalInsights/workspaces/law-unit-test"
+      metrics = [{
+        category = "AllMetrics"
+      }]
+    }
+  }
+
+  diagnostic_settings_queue = {
+    normalized = {
+      name                  = "queue-diagnostic-setting"
+      workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.OperationalInsights/workspaces/law-unit-test"
+      metrics = [
+        {
+          category = "AllMetrics"
+          enabled  = false
+          retention_policy = {
+            days    = 30
+            enabled = true
+          }
+        },
+        {
+          category = "Capacity"
+          enabled  = true
+          retention_policy = {
+            days    = 5
+            enabled = false
+          }
+        },
+        {
+          category = "CustomMetric"
+          enabled  = false
+        }
+      ]
+    }
+  }
+
+  diagnostic_settings_storage_account = {
+    unchanged = {
+      name                  = "account-diagnostic-setting"
+      workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.OperationalInsights/workspaces/law-unit-test"
+      metrics = [{
+        category = "AllMetrics"
+      }]
+    }
+  }
+
+  diagnostic_settings_table = {
+    normalized = {
+      name                  = "table-all-metrics-diagnostic-setting"
+      workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.OperationalInsights/workspaces/law-unit-test"
+      metrics = [{
+        category = "AllMetrics"
+      }]
+    }
+    passthrough = {
+      name                  = "table-diagnostic-setting"
+      workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.OperationalInsights/workspaces/law-unit-test"
+      metrics = [{
+        category = "Transaction"
+        enabled  = false
+        retention_policy = {
+          days    = 14
+          enabled = true
+        }
+      }]
+    }
+  }
+}
+
+run "normalize_storage_service_metrics" {
+  command = plan
+
+  assert {
+    condition = length(module.diagnostic_setting_blob.resources["normalized"].body.properties.metrics) == 2 && toset([
+      for metric in module.diagnostic_setting_blob.resources["normalized"].body.properties.metrics : metric.category
+    ]) == toset(["Capacity", "Transaction"])
+    error_message = "Blob AllMetrics must normalize to Capacity and Transaction."
+  }
+
+  assert {
+    condition = alltrue([
+      for metric in module.diagnostic_setting_blob.resources["normalized"].body.properties.metrics :
+      metric.enabled == false && metric.retentionPolicy.days == 7 && metric.retentionPolicy.enabled == true
+    ])
+    error_message = "Expanded Blob metrics must preserve enabled and retention_policy."
+  }
+
+  assert {
+    condition = length(module.diagnostic_setting_file.resources["normalized"].body.properties.metrics) == 3 && toset([
+      for metric in module.diagnostic_setting_file.resources["normalized"].body.properties.metrics : metric.category
+    ]) == toset(["Capacity", "SLI", "Transaction"])
+    error_message = "File AllMetrics must normalize to all supported metric categories, including SLI."
+  }
+
+  assert {
+    condition = alltrue([
+      for metric in module.diagnostic_setting_file.resources["normalized"].body.properties.metrics :
+      metric.enabled == true && metric.retentionPolicy.days == 0 && metric.retentionPolicy.enabled == false
+    ])
+    error_message = "Expanded File metrics must preserve the default enabled and retention_policy values."
+  }
+
+  assert {
+    condition = length(module.diagnostic_setting_queue.resources["normalized"].body.properties.metrics) == 3 && toset([
+      for metric in module.diagnostic_setting_queue.resources["normalized"].body.properties.metrics : metric.category
+    ]) == toset(["Capacity", "CustomMetric", "Transaction"])
+    error_message = "Queue normalization must deduplicate explicit concrete categories and preserve custom categories."
+  }
+
+  assert {
+    condition = one([
+      for metric in module.diagnostic_setting_queue.resources["normalized"].body.properties.metrics : metric
+      if metric.category == "Capacity"
+      ]).enabled == true && one([
+      for metric in module.diagnostic_setting_queue.resources["normalized"].body.properties.metrics : metric
+      if metric.category == "Capacity"
+    ]).retentionPolicy.days == 5
+    error_message = "An explicit Queue metric must take precedence over the category generated from AllMetrics."
+  }
+
+  assert {
+    condition = one([
+      for metric in module.diagnostic_setting_queue.resources["normalized"].body.properties.metrics : metric
+      if metric.category == "Transaction"
+      ]).enabled == false && one([
+      for metric in module.diagnostic_setting_queue.resources["normalized"].body.properties.metrics : metric
+      if metric.category == "Transaction"
+    ]).retentionPolicy.days == 30
+    error_message = "A generated Queue metric must preserve the AllMetrics properties."
+  }
+
+  assert {
+    condition = one([
+      for metric in module.diagnostic_setting_queue.resources["normalized"].body.properties.metrics : metric
+      if metric.category == "CustomMetric"
+    ]).enabled == false
+    error_message = "Non-AllMetrics Queue entries must pass through unchanged."
+  }
+
+  assert {
+    condition = length(module.diagnostic_setting_table.resources["normalized"].body.properties.metrics) == 2 && toset([
+      for metric in module.diagnostic_setting_table.resources["normalized"].body.properties.metrics : metric.category
+    ]) == toset(["Capacity", "Transaction"])
+    error_message = "Table AllMetrics must normalize to Capacity and Transaction."
+  }
+
+  assert {
+    condition = one(module.diagnostic_setting_table.resources["passthrough"].body.properties.metrics).category == "Transaction" && one(
+      module.diagnostic_setting_table.resources["passthrough"].body.properties.metrics
+    ).retentionPolicy.days == 14
+    error_message = "Concrete Table metrics and their properties must pass through unchanged."
+  }
+
+  assert {
+    condition = one(
+      module.diagnostic_setting_storage_account.resources["unchanged"].body.properties.metrics
+    ).category == "AllMetrics"
+    error_message = "Storage-account-scope AllMetrics must not be normalized."
+  }
+}


### PR DESCRIPTION
## Summary

- normalize `AllMetrics` to the concrete metric categories Azure returns for blob, file, queue, and table service diagnostic settings
- preserve explicit category settings, `enabled`, and retention properties while deduplicating generated categories
- exercise `AllMetrics` in the complete example so CI verifies apply/plan idempotency

Azure Files includes the additional `SLI` category; the storage-account scope remains unchanged because Azure returns `AllMetrics` atomically there.

## Validation

- `./avm.ps1 tf-test-unit`
- `./avm.ps1 pre-commit`
- the complete example provides the live apply followed by clean-plan coverage in PR CI

The local `pr-check` reached the Azure-backed example plans but could not complete because the local Azure CLI token cache requires a fresh login. The preceding documentation, mapotf, and lint checks passed.

## References

Fixes #318.

Supersedes #333, which identified the original normalization approach for the pre-v0.7 AzureRM implementation. This PR implements the fix for the current AzAPI architecture.