### PR TITLE
fix: retry transient storage account operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1099,11 +1099,13 @@ Default: `{}`
 
 ### <a name="input_retry"></a> [retry](#input\_retry)
 
-Description: Retry configuration applied to every `azapi` resource managed by the module (root storage account and all submodules). Defaults to `null` (no custom retry).
+Description: Retry configuration applied to every `azapi` resource managed by the module (root storage account and all submodules). By default, retries only the transient `StorageAccountOperationInProgress` error, starting at 5 seconds and capping the interval at 60 seconds.
 
-- `error_message_regex`  - (Optional) A list of regex patterns matching error messages that trigger a retry.
-- `interval_seconds`     - (Optional) Initial interval between retries in seconds.
-- `max_interval_seconds` - (Optional) Maximum interval between retries in seconds.
+- `error_message_regex`  - (Optional) A list of regex patterns matching error messages that trigger a retry. Supplying this field replaces the default list; include `StorageAccountOperationInProgress` to retain the module's transient storage-operation retry.
+- `interval_seconds`     - (Optional) Initial interval between retries in seconds. Defaults to `5`.
+- `max_interval_seconds` - (Optional) Maximum interval between retries in seconds. Defaults to `60`.
+
+Set `retry = null` to disable custom retries. The default deliberately does not retry generic HTTP 403 or 409 responses, so authorization failures and permanent conflicts remain visible.
 
 See <https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource#retry> for full semantics.
 
@@ -1111,13 +1113,13 @@ Type:
 
 ```hcl
 object({
-    error_message_regex  = optional(list(string))
-    interval_seconds     = optional(number)
-    max_interval_seconds = optional(number)
+    error_message_regex  = optional(list(string), ["StorageAccountOperationInProgress"])
+    interval_seconds     = optional(number, 5)
+    max_interval_seconds = optional(number, 60)
   })
 ```
 
-Default: `null`
+Default: `{}`
 
 ### <a name="input_role_assignment_definition_lookup_enabled"></a> [role\_assignment\_definition\_lookup\_enabled](#input\_role\_assignment\_definition\_lookup\_enabled)
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -391,7 +391,7 @@ module "this" {
   # Module-wide retry. Applies to every AzAPI resource managed by the module
   # and every submodule unless overridden per-item.
   retry = {
-    error_message_regex  = ["TooManyRequests", "ResourceNotFound", "RetryableError"]
+    error_message_regex  = ["StorageAccountOperationInProgress", "TooManyRequests", "ResourceNotFound", "RetryableError"]
     interval_seconds     = 5
     max_interval_seconds = 60
   }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -374,7 +374,7 @@ module "this" {
   # Module-wide retry. Applies to every AzAPI resource managed by the module
   # and every submodule unless overridden per-item.
   retry = {
-    error_message_regex  = ["TooManyRequests", "ResourceNotFound", "RetryableError"]
+    error_message_regex  = ["StorageAccountOperationInProgress", "TooManyRequests", "ResourceNotFound", "RetryableError"]
     interval_seconds     = 5
     max_interval_seconds = 60
   }

--- a/tests/unit/retry_timeouts.tftest.hcl
+++ b/tests/unit/retry_timeouts.tftest.hcl
@@ -12,7 +12,26 @@ variables {
   account_replication_type = "LRS"
 }
 
-run "retry_null_omitted" {
+run "retry_default_storage_contention" {
+  command = plan
+
+  assert {
+    condition     = length(azapi_resource.this.retry.error_message_regex) == 1 && azapi_resource.this.retry.error_message_regex[0] == "StorageAccountOperationInProgress"
+    error_message = "Expected the default retry to match only StorageAccountOperationInProgress"
+  }
+
+  assert {
+    condition     = azapi_resource.this.retry.interval_seconds == 5
+    error_message = "Expected the default retry.interval_seconds == 5"
+  }
+
+  assert {
+    condition     = azapi_resource.this.retry.max_interval_seconds == 60
+    error_message = "Expected the default retry.max_interval_seconds == 60"
+  }
+}
+
+run "retry_explicitly_disabled" {
   command = plan
 
   variables {
@@ -22,6 +41,31 @@ run "retry_null_omitted" {
   assert {
     condition     = azapi_resource.this.retry == null
     error_message = "Expected retry to be null when var.retry is null"
+  }
+}
+
+run "retry_regex_override" {
+  command = plan
+
+  variables {
+    retry = {
+      error_message_regex = ["TooManyRequests"]
+    }
+  }
+
+  assert {
+    condition     = length(azapi_resource.this.retry.error_message_regex) == 1 && azapi_resource.this.retry.error_message_regex[0] == "TooManyRequests"
+    error_message = "Expected a custom retry regex list to replace the default list"
+  }
+
+  assert {
+    condition     = azapi_resource.this.retry.interval_seconds == 5
+    error_message = "Expected the default retry.interval_seconds == 5 when only regexes are overridden"
+  }
+
+  assert {
+    condition     = azapi_resource.this.retry.max_interval_seconds == 60
+    error_message = "Expected the default retry.max_interval_seconds == 60 when only regexes are overridden"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -218,17 +218,19 @@ DESCRIPTION
 
 variable "retry" {
   type = object({
-    error_message_regex  = optional(list(string))
-    interval_seconds     = optional(number)
-    max_interval_seconds = optional(number)
+    error_message_regex  = optional(list(string), ["StorageAccountOperationInProgress"])
+    interval_seconds     = optional(number, 5)
+    max_interval_seconds = optional(number, 60)
   })
-  default     = null
+  default     = {}
   description = <<DESCRIPTION
-Retry configuration applied to every `azapi` resource managed by the module (root storage account and all submodules). Defaults to `null` (no custom retry).
+Retry configuration applied to every `azapi` resource managed by the module (root storage account and all submodules). By default, retries only the transient `StorageAccountOperationInProgress` error, starting at 5 seconds and capping the interval at 60 seconds.
 
-- `error_message_regex`  - (Optional) A list of regex patterns matching error messages that trigger a retry.
-- `interval_seconds`     - (Optional) Initial interval between retries in seconds.
-- `max_interval_seconds` - (Optional) Maximum interval between retries in seconds.
+- `error_message_regex`  - (Optional) A list of regex patterns matching error messages that trigger a retry. Supplying this field replaces the default list; include `StorageAccountOperationInProgress` to retain the module's transient storage-operation retry.
+- `interval_seconds`     - (Optional) Initial interval between retries in seconds. Defaults to `5`.
+- `max_interval_seconds` - (Optional) Maximum interval between retries in seconds. Defaults to `60`.
+
+Set `retry = null` to disable custom retries. The default deliberately does not retry generic HTTP 403 or 409 responses, so authorization failures and permanent conflicts remain visible.
 
 See <https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource#retry> for full semantics.
 DESCRIPTION


### PR DESCRIPTION
## Summary

Azure Storage can temporarily return `StorageAccountOperationInProgress` when concurrent operations require exclusive access. Because the module did not retry this error, otherwise valid example deployments and cleanup could fail intermittently.

This PR:

- retries only the exact `StorageAccountOperationInProgress` error by default;
- uses bounded retry intervals of 5–60 seconds;
- keeps other `409` and `403` errors visible;
- allows consumers to override the retry settings or disable them with `retry = null`.

The retry applies through the module's existing storage-account and submodule wiring.

## Validation

- Unit and pre-commit checks passed.
- All PR CI checks and live examples passed on the first attempt.

Observed in [workflow run 30845342111](https://github.com/Azure/terraform-azurerm-avm-res-storage-storageaccount/actions/runs/30845342111).