### PR TITLE
feat: support Provisioned v2 file share performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,12 +1242,14 @@ Type:
 
 ```hcl
 map(object({
-    access_tier      = optional(string)
-    enabled_protocol = optional(string)
-    metadata         = optional(map(string))
-    name             = string
-    quota            = number
-    root_squash      = optional(string)
+    access_tier                 = optional(string)
+    enabled_protocol            = optional(string)
+    metadata                    = optional(map(string))
+    name                        = string
+    quota                       = number
+    provisioned_bandwidth_mibps = optional(number)
+    provisioned_iops            = optional(number)
+    root_squash                 = optional(string)
     signed_identifiers = optional(list(object({
       id = string
       access_policy = optional(object({

--- a/README.md
+++ b/README.md
@@ -1221,6 +1221,8 @@ Description: A map of file shares to create on the storage account. The map key 
 
 - `name` - (Required) The name of the share. Must be unique within the storage account. Changing this forces a new resource to be created.
 - `quota` - (Required) The maximum size of the share, in gigabytes. For Standard storage accounts, this must be `1` GB or higher and at most `5120` GB (5 TB). For Premium FileStorage accounts, this must be greater than 100 GB and at most `102400` GB (100 TB).
+- `provisioned_bandwidth_mibps` - (Optional) The provisioned bandwidth of the share, in MiB/s. Only valid for Files Provisioned v2 accounts. Defaults to `null`.
+- `provisioned_iops` - (Optional) The provisioned IOPS of the share. Only valid for Files Provisioned v2 accounts. Defaults to `null`.
 - `access_tier` - (Optional) The access tier of the file share. Possible values are `Hot`, `Cool`, `TransactionOptimized`, `Premium`. Defaults to `null` (Azure platform default).
 - `enabled_protocol` - (Optional) The protocol used for the share. Possible values are `SMB` and `NFS`. `SMB` indicates the share can be accessed by SMBv3.0, SMBv2.1 and REST. `NFS` indicates the share can be accessed by NFSv4.1. Defaults to `null` (Azure platform default of `SMB`). Changing this forces a new resource to be created.
 - `metadata` - (Optional) A mapping of MetaData for this File Share. Defaults to `null`.

--- a/examples/provisioned_billing_model_version/README.md
+++ b/examples/provisioned_billing_model_version/README.md
@@ -168,11 +168,11 @@ module "this" {
   shared_access_key_enabled = true
   shares = {
     premium_share = {
-      name             = "share-${random_string.this.result}-premium"
-      quota            = 100
-      provisioned_iops              = 3000
-      provisioned_bandwidth_mibps   = 100
-      enabled_protocol = "SMB"
+      name                        = "share-${random_string.this.result}-premium"
+      quota                       = 100
+      provisioned_iops            = 3000
+      provisioned_bandwidth_mibps = 100
+      enabled_protocol            = "SMB"
     }
   }
   tags = {

--- a/examples/provisioned_billing_model_version/README.md
+++ b/examples/provisioned_billing_model_version/README.md
@@ -170,6 +170,8 @@ module "this" {
     premium_share = {
       name             = "share-${random_string.this.result}-premium"
       quota            = 100
+      provisioned_iops              = 3000
+      provisioned_bandwidth_mibps   = 100
       enabled_protocol = "SMB"
     }
   }

--- a/examples/provisioned_billing_model_version/main.tf
+++ b/examples/provisioned_billing_model_version/main.tf
@@ -153,11 +153,11 @@ module "this" {
   shared_access_key_enabled = true
   shares = {
     premium_share = {
-      name             = "share-${random_string.this.result}-premium"
-      quota            = 100
-      provisioned_iops              = 3000
-      provisioned_bandwidth_mibps   = 100
-      enabled_protocol = "SMB"
+      name                        = "share-${random_string.this.result}-premium"
+      quota                       = 100
+      provisioned_iops            = 3000
+      provisioned_bandwidth_mibps = 100
+      enabled_protocol            = "SMB"
     }
   }
   tags = {

--- a/examples/provisioned_billing_model_version/main.tf
+++ b/examples/provisioned_billing_model_version/main.tf
@@ -155,6 +155,8 @@ module "this" {
     premium_share = {
       name             = "share-${random_string.this.result}-premium"
       quota            = 100
+      provisioned_iops              = 3000
+      provisioned_bandwidth_mibps   = 100
       enabled_protocol = "SMB"
     }
   }

--- a/main.shares.tf
+++ b/main.shares.tf
@@ -8,6 +8,8 @@ module "shares" {
   access_tier                               = each.value.access_tier
   enabled_protocol                          = each.value.enabled_protocol
   metadata                                  = each.value.metadata
+  provisioned_bandwidth_mibps               = each.value.provisioned_bandwidth_mibps
+  provisioned_iops                          = each.value.provisioned_iops
   resource_type                             = var.resource_types.share
   retry                                     = var.retry
   role_assignment_definition_lookup_enabled = var.role_assignment_definition_lookup_enabled

--- a/modules/share/README.md
+++ b/modules/share/README.md
@@ -71,6 +71,22 @@ Type: `map(string)`
 
 Default: `null`
 
+### <a name="input_provisioned_bandwidth_mibps"></a> [provisioned\_bandwidth\_mibps](#input\_provisioned\_bandwidth\_mibps)
+
+Description: (Optional) The provisioned bandwidth of the file share, in MiB/s, for Files Provisioned v2 accounts.
+
+Type: `number`
+
+Default: `null`
+
+### <a name="input_provisioned_iops"></a> [provisioned\_iops](#input\_provisioned\_iops)
+
+Description: (Optional) The provisioned IOPS of the file share for Files Provisioned v2 accounts.
+
+Type: `number`
+
+Default: `null`
+
 ### <a name="input_resource_type"></a> [resource\_type](#input\_resource\_type)
 
 Description: (Optional) Override the AzAPI `<provider>/<resource>@<api-version>` string used to manage the file share. Defaults to the value tested with this module version.

--- a/modules/share/main.tf
+++ b/modules/share/main.tf
@@ -4,14 +4,14 @@ resource "azapi_resource" "this" {
   type      = var.resource_type
   body = {
     properties = {
-      accessTier        = var.access_tier
-      enabledProtocols  = var.enabled_protocol
-      metadata          = var.metadata
-      shareQuota        = var.quota
+      accessTier                = var.access_tier
+      enabledProtocols          = var.enabled_protocol
+      metadata                  = var.metadata
+      shareQuota                = var.quota
       provisionedBandwidthMibps = var.provisioned_bandwidth_mibps
       provisionedIops           = var.provisioned_iops
-      rootSquash        = var.root_squash
-      signedIdentifiers = local.signed_identifiers_body
+      rootSquash                = var.root_squash
+      signedIdentifiers         = local.signed_identifiers_body
     }
   }
   create_headers            = local.tracing_headers

--- a/modules/share/main.tf
+++ b/modules/share/main.tf
@@ -8,6 +8,8 @@ resource "azapi_resource" "this" {
       enabledProtocols  = var.enabled_protocol
       metadata          = var.metadata
       shareQuota        = var.quota
+      provisionedBandwidthMibps = var.provisioned_bandwidth_mibps
+      provisionedIops           = var.provisioned_iops
       rootSquash        = var.root_squash
       signedIdentifiers = local.signed_identifiers_body
     }

--- a/modules/share/variables.tf
+++ b/modules/share/variables.tf
@@ -10,6 +10,18 @@ variable "quota" {
   nullable    = false
 }
 
+variable "provisioned_bandwidth_mibps" {
+  type        = number
+  default     = null
+  description = "(Optional) The provisioned bandwidth of the file share, in MiB/s, for Files Provisioned v2 accounts."
+}
+
+variable "provisioned_iops" {
+  type        = number
+  default     = null
+  description = "(Optional) The provisioned IOPS of the file share for Files Provisioned v2 accounts."
+}
+
 variable "storage_account_id" {
   type        = string
   description = "(Required) The full resource ID of the parent storage account."

--- a/modules/share/variables.tf
+++ b/modules/share/variables.tf
@@ -10,6 +10,12 @@ variable "quota" {
   nullable    = false
 }
 
+variable "storage_account_id" {
+  type        = string
+  description = "(Required) The full resource ID of the parent storage account."
+  nullable    = false
+}
+
 variable "provisioned_bandwidth_mibps" {
   type        = number
   default     = null
@@ -20,12 +26,6 @@ variable "provisioned_iops" {
   type        = number
   default     = null
   description = "(Optional) The provisioned IOPS of the file share for Files Provisioned v2 accounts."
-}
-
-variable "storage_account_id" {
-  type        = string
-  description = "(Required) The full resource ID of the parent storage account."
-  nullable    = false
 }
 
 variable "access_tier" {

--- a/modules/share/variables.tf
+++ b/modules/share/variables.tf
@@ -16,18 +16,6 @@ variable "storage_account_id" {
   nullable    = false
 }
 
-variable "provisioned_bandwidth_mibps" {
-  type        = number
-  default     = null
-  description = "(Optional) The provisioned bandwidth of the file share, in MiB/s, for Files Provisioned v2 accounts."
-}
-
-variable "provisioned_iops" {
-  type        = number
-  default     = null
-  description = "(Optional) The provisioned IOPS of the file share for Files Provisioned v2 accounts."
-}
-
 variable "access_tier" {
   type        = string
   default     = null
@@ -44,6 +32,18 @@ variable "metadata" {
   type        = map(string)
   default     = null
   description = "(Optional) Metadata for the share. Defaults to `null` (no metadata)."
+}
+
+variable "provisioned_bandwidth_mibps" {
+  type        = number
+  default     = null
+  description = "(Optional) The provisioned bandwidth of the file share, in MiB/s, for Files Provisioned v2 accounts."
+}
+
+variable "provisioned_iops" {
+  type        = number
+  default     = null
+  description = "(Optional) The provisioned IOPS of the file share for Files Provisioned v2 accounts."
 }
 
 variable "resource_type" {

--- a/variables.share.tf
+++ b/variables.share.tf
@@ -49,12 +49,14 @@ variable "large_file_share_enabled" {
 
 variable "shares" {
   type = map(object({
-    access_tier      = optional(string)
-    enabled_protocol = optional(string)
-    metadata         = optional(map(string))
-    name             = string
-    quota            = number
-    root_squash      = optional(string)
+    access_tier                 = optional(string)
+    enabled_protocol            = optional(string)
+    metadata                    = optional(map(string))
+    name                        = string
+    quota                       = number
+    provisioned_bandwidth_mibps = optional(number)
+    provisioned_iops            = optional(number)
+    root_squash                 = optional(string)
     signed_identifiers = optional(list(object({
       id = string
       access_policy = optional(object({

--- a/variables.share.tf
+++ b/variables.share.tf
@@ -88,6 +88,8 @@ A map of file shares to create on the storage account. The map key is arbitrary;
 
 - `name` - (Required) The name of the share. Must be unique within the storage account. Changing this forces a new resource to be created.
 - `quota` - (Required) The maximum size of the share, in gigabytes. For Standard storage accounts, this must be `1` GB or higher and at most `5120` GB (5 TB). For Premium FileStorage accounts, this must be greater than 100 GB and at most `102400` GB (100 TB).
+- `provisioned_bandwidth_mibps` - (Optional) The provisioned bandwidth of the share, in MiB/s. Only valid for Files Provisioned v2 accounts. Defaults to `null`.
+- `provisioned_iops` - (Optional) The provisioned IOPS of the share. Only valid for Files Provisioned v2 accounts. Defaults to `null`.
 - `access_tier` - (Optional) The access tier of the file share. Possible values are `Hot`, `Cool`, `TransactionOptimized`, `Premium`. Defaults to `null` (Azure platform default).
 - `enabled_protocol` - (Optional) The protocol used for the share. Possible values are `SMB` and `NFS`. `SMB` indicates the share can be accessed by SMBv3.0, SMBv2.1 and REST. `NFS` indicates the share can be accessed by NFSv4.1. Defaults to `null` (Azure platform default of `SMB`). Changing this forces a new resource to be created.
 - `metadata` - (Optional) A mapping of MetaData for this File Share. Defaults to `null`.


### PR DESCRIPTION
## Description

Adds per-share `provisioned_iops` and `provisioned_bandwidth_mibps` inputs for Azure Files Provisioned v2. The values flow from the root `shares` map through the share submodule into the `Microsoft.Storage/storageAccounts/fileServices/shares` AzAPI request. The existing Provisioned v2 example now exercises both settings.

Closes #324

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks