### PR TITLE
fix: propagate edge zones to private endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,6 +911,7 @@ Description: A map of private endpoints to create on the resource. The map key i
 - `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set. Defaults to `null`.
 - `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set. Defaults to `null`.
 - `location` - (Optional) The Azure location where the resources will be deployed. Defaults to the location of the storage account.
+- `edge_zone` - (Optional) The Edge Zone within the Azure region where the private endpoint should exist. Defaults to the storage account's `edge_zone`.
 - `resource_group_name` - (Optional) The resource group where the resources will be deployed. Defaults to the resource group of the storage account.
 - `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. Defaults to `{}` (the platform allocates IPs). The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time. Each value supports:
   - `name` - (Required) The name of the IP configuration.
@@ -944,6 +945,7 @@ map(object({
     private_service_connection_name         = optional(string, null)
     network_interface_name                  = optional(string, null)
     location                                = optional(string, null)
+    edge_zone                               = optional(string, null)
     resource_group_name                     = optional(string, null)
     ip_configurations = optional(map(object({
       name               = string

--- a/README.md
+++ b/README.md
@@ -1638,6 +1638,7 @@ Description: A map of private endpoints created by the module. The map key match
 Each value is an object with:
 - `id` - The resource ID of the private endpoint.
 - `name` - The name of the private endpoint.
+- `edge_zone` - The Edge Zone the private endpoint was placed in, inherited from `var.edge_zone`, or `null` when the private endpoint is regional.
 - `private_dns_zone_group_id` - The resource ID of the managed private DNS zone group, or `null` if not managed by this module.
 - `role_assignments` - Map of role assignments created at the private endpoint scope.
 

--- a/README.md
+++ b/README.md
@@ -911,7 +911,6 @@ Description: A map of private endpoints to create on the resource. The map key i
 - `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set. Defaults to `null`.
 - `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set. Defaults to `null`.
 - `location` - (Optional) The Azure location where the resources will be deployed. Defaults to the location of the storage account.
-- `edge_zone` - (Optional) The Edge Zone within the Azure region where the private endpoint should exist. Defaults to the storage account's `edge_zone`.
 - `resource_group_name` - (Optional) The resource group where the resources will be deployed. Defaults to the resource group of the storage account.
 - `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. Defaults to `{}` (the platform allocates IPs). The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time. Each value supports:
   - `name` - (Required) The name of the IP configuration.
@@ -945,7 +944,6 @@ map(object({
     private_service_connection_name         = optional(string, null)
     network_interface_name                  = optional(string, null)
     location                                = optional(string, null)
-    edge_zone                               = optional(string, null)
     resource_group_name                     = optional(string, null)
     ip_configurations = optional(map(object({
       name               = string

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -10,7 +10,7 @@ module "private_endpoints" {
   subresource_name                          = each.value.subresource_name
   application_security_group_resource_ids   = each.value.application_security_group_associations
   dns_zone_group_resource_type              = var.resource_types.private_dns_zone_group
-  edge_zone                                 = each.value.edge_zone != null ? each.value.edge_zone : var.edge_zone
+  edge_zone                                 = var.edge_zone
   ip_configurations                         = each.value.ip_configurations
   lock                                      = each.value.lock
   lock_resource_type                        = var.resource_types.lock

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -10,6 +10,7 @@ module "private_endpoints" {
   subresource_name                          = each.value.subresource_name
   application_security_group_resource_ids   = each.value.application_security_group_associations
   dns_zone_group_resource_type              = var.resource_types.private_dns_zone_group
+  edge_zone                                 = each.value.edge_zone != null ? each.value.edge_zone : var.edge_zone
   ip_configurations                         = each.value.ip_configurations
   lock                                      = each.value.lock
   lock_resource_type                        = var.resource_types.lock

--- a/modules/private_endpoint/README.md
+++ b/modules/private_endpoint/README.md
@@ -276,7 +276,7 @@ The following outputs are exported:
 
 ### <a name="output_extended_location"></a> [extended\_location](#output\_extended\_location)
 
-Description: The extended location sent in the private endpoint request, or `null` when the private endpoint is regional.
+Description: The extended location sent in the private endpoint request as `{ name, type }`, or `null` when the private endpoint is regional. Consumed by the root module's `private_endpoints` output.
 
 ### <a name="output_name"></a> [name](#output\_name)
 

--- a/modules/private_endpoint/README.md
+++ b/modules/private_endpoint/README.md
@@ -83,6 +83,14 @@ Type: `string`
 
 Default: `"Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2025-05-01"`
 
+### <a name="input_edge_zone"></a> [edge\_zone](#input\_edge\_zone)
+
+Description: (Optional) The Edge Zone within the Azure region where the private endpoint should exist. Defaults to `null`.
+
+Type: `string`
+
+Default: `null`
+
 ### <a name="input_ip_configurations"></a> [ip\_configurations](#input\_ip\_configurations)
 
 Description: (Optional) Static IP configurations for the private endpoint. Defaults to `{}` (the platform allocates IPs). The map key is arbitrary; each value supports:
@@ -265,6 +273,10 @@ Default: `null`
 ## Outputs
 
 The following outputs are exported:
+
+### <a name="output_extended_location"></a> [extended\_location](#output\_extended\_location)
+
+Description: The extended location sent in the private endpoint request, or `null` when the private endpoint is regional.
 
 ### <a name="output_name"></a> [name](#output\_name)
 

--- a/modules/private_endpoint/main.tf
+++ b/modules/private_endpoint/main.tf
@@ -3,32 +3,40 @@ resource "azapi_resource" "this" {
   name      = var.name
   parent_id = var.parent_id
   type      = var.resource_type
-  body = {
-    # customNetworkInterfaceName is only included when set. Azure stores an unset
-    # custom NIC name as an empty string, so sending null would cause a perpetual
-    # "" -> null diff and break idempotency.
-    properties = merge(
-      {
-        subnet = {
-          id = var.subnet_resource_id
-        }
-        privateLinkServiceConnections = [
-          {
-            name = var.private_service_connection_name == null ? "pse-${var.name}" : var.private_service_connection_name
-            properties = {
-              privateLinkServiceId = var.private_connection_resource_id
-              groupIds             = [var.subresource_name]
-            }
+  body = merge(
+    {
+      # customNetworkInterfaceName is only included when set. Azure stores an unset
+      # custom NIC name as an empty string, so sending null would cause a perpetual
+      # "" -> null diff and break idempotency.
+      properties = merge(
+        {
+          subnet = {
+            id = var.subnet_resource_id
           }
-        ]
-        ipConfigurations          = local.ip_configurations_body
-        applicationSecurityGroups = local.asg_body
-      },
-      var.network_interface_name == null ? {} : {
-        customNetworkInterfaceName = var.network_interface_name
+          privateLinkServiceConnections = [
+            {
+              name = var.private_service_connection_name == null ? "pse-${var.name}" : var.private_service_connection_name
+              properties = {
+                privateLinkServiceId = var.private_connection_resource_id
+                groupIds             = [var.subresource_name]
+              }
+            }
+          ]
+          ipConfigurations          = local.ip_configurations_body
+          applicationSecurityGroups = local.asg_body
+        },
+        var.network_interface_name == null ? {} : {
+          customNetworkInterfaceName = var.network_interface_name
+        }
+      )
+    },
+    var.edge_zone == null ? {} : {
+      extendedLocation = {
+        name = var.edge_zone
+        type = "EdgeZone"
       }
-    )
-  }
+    }
+  )
   create_headers         = local.tracing_headers
   delete_headers         = local.tracing_headers
   read_headers           = local.tracing_headers

--- a/modules/private_endpoint/outputs.tf
+++ b/modules/private_endpoint/outputs.tf
@@ -4,7 +4,7 @@ output "name" {
 }
 
 output "extended_location" {
-  description = "The extended location sent in the private endpoint request, or `null` when the private endpoint is regional."
+  description = "The extended location sent in the private endpoint request as `{ name, type }`, or `null` when the private endpoint is regional. Consumed by the root module's `private_endpoints` output."
   value       = try(azapi_resource.this.body.extendedLocation, null)
 }
 

--- a/modules/private_endpoint/outputs.tf
+++ b/modules/private_endpoint/outputs.tf
@@ -3,6 +3,11 @@ output "name" {
   value       = azapi_resource.this.name
 }
 
+output "extended_location" {
+  description = "The extended location sent in the private endpoint request, or `null` when the private endpoint is regional."
+  value       = try(azapi_resource.this.body.extendedLocation, null)
+}
+
 output "private_dns_zone_group_id" {
   description = "The resource ID of the private DNS zone group (if managed by this module), otherwise `null`."
   value       = length(azapi_resource.private_dns_zone_group) > 0 ? azapi_resource.private_dns_zone_group[0].id : null

--- a/modules/private_endpoint/variables.tf
+++ b/modules/private_endpoint/variables.tf
@@ -48,6 +48,12 @@ variable "dns_zone_group_resource_type" {
   nullable    = false
 }
 
+variable "edge_zone" {
+  type        = string
+  default     = null
+  description = "(Optional) The Edge Zone within the Azure region where the private endpoint should exist. Defaults to `null`."
+}
+
 variable "ip_configurations" {
   type = map(object({
     name               = string

--- a/outputs.tf
+++ b/outputs.tf
@@ -79,6 +79,7 @@ A map of private endpoints created by the module. The map key matches `var.priva
 Each value is an object with:
 - `id` - The resource ID of the private endpoint.
 - `name` - The name of the private endpoint.
+- `edge_zone` - The Edge Zone the private endpoint was placed in, inherited from `var.edge_zone`, or `null` when the private endpoint is regional.
 - `private_dns_zone_group_id` - The resource ID of the managed private DNS zone group, or `null` if not managed by this module.
 - `role_assignments` - Map of role assignments created at the private endpoint scope.
 DESCRIPTION
@@ -87,6 +88,7 @@ DESCRIPTION
     k => {
       id                        = m.resource_id
       name                      = m.name
+      edge_zone                 = try(m.extended_location.name, null)
       private_dns_zone_group_id = m.private_dns_zone_group_id
       role_assignments          = m.role_assignments
     }

--- a/tests/unit/private_endpoint_edge_zone.tftest.hcl
+++ b/tests/unit/private_endpoint_edge_zone.tftest.hcl
@@ -31,6 +31,13 @@ run "root_edge_zone_propagates_to_private_endpoint" {
     }
     error_message = "Expected the private endpoint request to inherit the storage account Edge Zone."
   }
+
+  # Azure rejects an endpoint placed differently from its account with
+  # VnetSpanningForEdgeZonesNotEnabled, so pin the two together.
+  assert {
+    condition     = azapi_resource.this.body.extendedLocation == module.private_endpoints["inherited"].extended_location
+    error_message = "Expected the storage account and its private endpoint to share one Edge Zone placement."
+  }
 }
 
 run "regional_private_endpoint_omits_extended_location" {

--- a/tests/unit/private_endpoint_edge_zone.tftest.hcl
+++ b/tests/unit/private_endpoint_edge_zone.tftest.hcl
@@ -38,6 +38,29 @@ run "root_edge_zone_propagates_to_private_endpoint" {
     condition     = azapi_resource.this.body.extendedLocation == module.private_endpoints["inherited"].extended_location
     error_message = "Expected the storage account and its private endpoint to share one Edge Zone placement."
   }
+
+  assert {
+    condition     = output.private_endpoints["inherited"].edge_zone == "perth"
+    error_message = "Expected the root private_endpoints output to report the inherited Edge Zone."
+  }
+}
+
+run "regional_root_output_reports_null_edge_zone" {
+  command = plan
+
+  variables {
+    private_endpoints = {
+      regional = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-regional/subnets/snet-private-endpoints"
+        subresource_name   = "blob"
+      }
+    }
+  }
+
+  assert {
+    condition     = output.private_endpoints["regional"].edge_zone == null
+    error_message = "Expected the root private_endpoints output to report a null Edge Zone for a regional endpoint."
+  }
 }
 
 run "regional_private_endpoint_omits_extended_location" {

--- a/tests/unit/private_endpoint_edge_zone.tftest.hcl
+++ b/tests/unit/private_endpoint_edge_zone.tftest.hcl
@@ -1,0 +1,80 @@
+# Unit tests for private endpoint Edge Zone propagation and request shaping.
+mock_provider "azapi" {}
+mock_provider "modtm" {}
+mock_provider "random" {}
+
+variables {
+  location                 = "australiaeast"
+  name                     = "stunittest001"
+  parent_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test"
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+run "root_edge_zone_propagates_to_private_endpoint" {
+  command = plan
+
+  variables {
+    edge_zone = "perth"
+    private_endpoints = {
+      inherited = {
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-edge/subnets/snet-private-endpoints"
+        subresource_name   = "blob"
+      }
+    }
+  }
+
+  assert {
+    condition = module.private_endpoints["inherited"].extended_location == {
+      name = "perth"
+      type = "EdgeZone"
+    }
+    error_message = "Expected the private endpoint request to inherit the storage account Edge Zone."
+  }
+}
+
+run "regional_private_endpoint_omits_extended_location" {
+  command = plan
+
+  module {
+    source = "./modules/private_endpoint"
+  }
+
+  variables {
+    location                                  = "australiaeast"
+    name                                      = "pe-regional"
+    parent_id                                 = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test"
+    private_connection_resource_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.Storage/storageAccounts/stunittest001"
+    subnet_resource_id                        = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-regional/subnets/snet-private-endpoints"
+    subresource_name                          = "blob"
+    role_assignment_definition_lookup_enabled = false
+  }
+
+  assert {
+    condition     = !can(azapi_resource.this.body.extendedLocation)
+    error_message = "Expected a regional private endpoint request to omit extendedLocation entirely."
+  }
+}
+
+run "private_endpoint_edge_zone_overrides_root" {
+  command = plan
+
+  variables {
+    edge_zone = "perth"
+    private_endpoints = {
+      overridden = {
+        edge_zone          = "losangeles"
+        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-edge/subnets/snet-private-endpoints"
+        subresource_name   = "blob"
+      }
+    }
+  }
+
+  assert {
+    condition = module.private_endpoints["overridden"].extended_location == {
+      name = "losangeles"
+      type = "EdgeZone"
+    }
+    error_message = "Expected the private endpoint Edge Zone override to replace the storage account Edge Zone."
+  }
+}

--- a/tests/unit/private_endpoint_edge_zone.tftest.hcl
+++ b/tests/unit/private_endpoint_edge_zone.tftest.hcl
@@ -55,26 +55,3 @@ run "regional_private_endpoint_omits_extended_location" {
     error_message = "Expected a regional private endpoint request to omit extendedLocation entirely."
   }
 }
-
-run "private_endpoint_edge_zone_overrides_root" {
-  command = plan
-
-  variables {
-    edge_zone = "perth"
-    private_endpoints = {
-      overridden = {
-        edge_zone          = "losangeles"
-        subnet_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-network/providers/Microsoft.Network/virtualNetworks/vnet-edge/subnets/snet-private-endpoints"
-        subresource_name   = "blob"
-      }
-    }
-  }
-
-  assert {
-    condition = module.private_endpoints["overridden"].extended_location == {
-      name = "losangeles"
-      type = "EdgeZone"
-    }
-    error_message = "Expected the private endpoint Edge Zone override to replace the storage account Edge Zone."
-  }
-}

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,7 @@ variable "private_endpoints" {
     private_service_connection_name         = optional(string, null)
     network_interface_name                  = optional(string, null)
     location                                = optional(string, null)
+    edge_zone                               = optional(string, null)
     resource_group_name                     = optional(string, null)
     ip_configurations = optional(map(object({
       name               = string
@@ -160,6 +161,7 @@ A map of private endpoints to create on the resource. The map key is deliberatel
 - `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set. Defaults to `null`.
 - `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set. Defaults to `null`.
 - `location` - (Optional) The Azure location where the resources will be deployed. Defaults to the location of the storage account.
+- `edge_zone` - (Optional) The Edge Zone within the Azure region where the private endpoint should exist. Defaults to the storage account's `edge_zone`.
 - `resource_group_name` - (Optional) The resource group where the resources will be deployed. Defaults to the resource group of the storage account.
 - `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. Defaults to `{}` (the platform allocates IPs). The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time. Each value supports:
   - `name` - (Required) The name of the IP configuration.

--- a/variables.tf
+++ b/variables.tf
@@ -128,7 +128,6 @@ variable "private_endpoints" {
     private_service_connection_name         = optional(string, null)
     network_interface_name                  = optional(string, null)
     location                                = optional(string, null)
-    edge_zone                               = optional(string, null)
     resource_group_name                     = optional(string, null)
     ip_configurations = optional(map(object({
       name               = string
@@ -161,7 +160,6 @@ A map of private endpoints to create on the resource. The map key is deliberatel
 - `private_service_connection_name` - (Optional) The name of the private service connection. One will be generated if not set. Defaults to `null`.
 - `network_interface_name` - (Optional) The name of the network interface. One will be generated if not set. Defaults to `null`.
 - `location` - (Optional) The Azure location where the resources will be deployed. Defaults to the location of the storage account.
-- `edge_zone` - (Optional) The Edge Zone within the Azure region where the private endpoint should exist. Defaults to the storage account's `edge_zone`.
 - `resource_group_name` - (Optional) The resource group where the resources will be deployed. Defaults to the resource group of the storage account.
 - `ip_configurations` - (Optional) A map of IP configurations to create on the private endpoint. Defaults to `{}` (the platform allocates IPs). The map key is deliberately arbitrary to avoid issues where map keys may be unknown at plan time. Each value supports:
   - `name` - (Required) The name of the IP configuration.


### PR DESCRIPTION
## Problem

When `edge_zone = "perth"` is set, the storage account request includes `body.extendedLocation`, but the private endpoint child module previously received no Edge Zone value. Its `Microsoft.Network/privateEndpoints` request therefore omitted `extendedLocation`, and Azure rejected the cross-placement network operation with `400 VnetSpanningForEdgeZonesNotEnabled`.

## Change

- Pass the root storage account `edge_zone` into every managed private endpoint automatically.
- Emit top-level `body.extendedLocation = { name = <zone>, type = "EdgeZone" }` in the private endpoint AzAPI request when configured.
- Merge the optional field into the request so ordinary regional private endpoints omit `extendedLocation` entirely rather than sending `null`.
- Add mock tests for root Edge Zone propagation and regional omission.
- Regenerate root and private endpoint submodule documentation through AVM tooling.

A per-endpoint override was intentionally not added because the current AVM standard `private_endpoints` interface requires an exact object schema and rejects additional fields. Automatic inheritance fixes the reported configuration without redundant caller input and preserves interface compliance.

## Validation

- `./avm tf-test-unit` — passed
- `./avm pre-commit` — passed
- `./avm pr-check` — formatting, validation, docs, unit tests, and TFLint passed; local Well-Architected example plans could not complete because the Azure CLI token is absent on this machine and will run with credentials in CI

## Testing scope

Coverage for the Edge Zone path is by mock unit test rather than a deployed example, and this is deliberate.

The tests assert the exact request shape (`{ name = "perth", type = "EdgeZone" }`), assert regional endpoints omit `extendedLocation` entirely, and assert the storage account and its private endpoint carry the *same* placement - the divergence that produces `VnetSpanningForEdgeZonesNotEnabled`. Reverting the one-line propagation in `main.privateendpoint.tf` was verified to fail these tests, so they guard against regression rather than restating the implementation.

An `examples/` deployment was considered and rejected: Azure Extended Zones require `Microsoft.EdgeZones` provider registration plus per-subscription access approval and per-zone registration. Since `test-examples` applies every directory under `examples/` with no opt-out, an Edge Zone example would hard-fail CI on any subscription lacking that grant.

Closes #365

