### PR TITLE
fix: allow Capacity metric category for storage account diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Description: A map of diagnostic settings to create on the Storage Account itsel
 
 This variable uses the v2 diagnostic settings interface from `Azure/avm-utl-interfaces/azure`, which fully supports all features of the Azure Diagnostic Settings API.
 
-**Important:** Diagnostic settings on the Storage Account resource itself support only metrics (logs are not supported by the Azure API at this scope). Supplying any `logs` entries here will be rejected by Azure. Supported metric categories are `Transaction` and `AllMetrics`.
+**Important:** Diagnostic settings on the Storage Account resource itself support only metrics (logs are not supported by the Azure API at this scope). Supplying any `logs` entries here will be rejected by Azure. Supported metric categories are `Capacity`, `Transaction`, and `AllMetrics`.
 
 See `var.diagnostic_settings_blob` for full attribute documentation; the schema is identical.
 

--- a/tests/unit/diagnostic_settings.tftest.hcl
+++ b/tests/unit/diagnostic_settings.tftest.hcl
@@ -188,3 +188,42 @@ run "normalize_storage_service_metrics" {
     error_message = "Storage-account-scope AllMetrics must not be normalized."
   }
 }
+
+run "storage_account_accepts_capacity_metric_category" {
+  command = plan
+
+  variables {
+    diagnostic_settings_storage_account = {
+      capacity = {
+        name                  = "account-capacity-diagnostic-setting"
+        workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.OperationalInsights/workspaces/law-unit-test"
+        metrics = [
+          { category = "Capacity" },
+          { category = "Transaction" },
+        ]
+      }
+    }
+  }
+
+  assert {
+    condition = toset([
+      for metric in module.diagnostic_setting_storage_account.resources["capacity"].body.properties.metrics : metric.category
+    ]) == toset(["Capacity", "Transaction"])
+    error_message = "Capacity must be accepted at the storage account scope and sent to Azure unchanged."
+  }
+}
+
+run "storage_account_rejects_unsupported_metric_category" {
+  command = plan
+
+  variables {
+    diagnostic_settings_storage_account = {
+      invalid = {
+        workspace_resource_id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-unit-test/providers/Microsoft.OperationalInsights/workspaces/law-unit-test"
+        metrics               = [{ category = "NotAMetricCategory" }]
+      }
+    }
+  }
+
+  expect_failures = [var.diagnostic_settings_storage_account]
+}

--- a/variables.diagnostics.tf
+++ b/variables.diagnostics.tf
@@ -202,7 +202,7 @@ A map of diagnostic settings to create on the Storage Account itself. The map ke
 
 This variable uses the v2 diagnostic settings interface from `Azure/avm-utl-interfaces/azure`, which fully supports all features of the Azure Diagnostic Settings API.
 
-**Important:** Diagnostic settings on the Storage Account resource itself support only metrics (logs are not supported by the Azure API at this scope). Supplying any `logs` entries here will be rejected by Azure. Supported metric categories are `Transaction` and `AllMetrics`.
+**Important:** Diagnostic settings on the Storage Account resource itself support only metrics (logs are not supported by the Azure API at this scope). Supplying any `logs` entries here will be rejected by Azure. Supported metric categories are `Capacity`, `Transaction`, and `AllMetrics`.
 
 See `var.diagnostic_settings_blob` for full attribute documentation; the schema is identical.
 DESCRIPTION
@@ -228,9 +228,9 @@ DESCRIPTION
   validation {
     condition = alltrue([
       for _, v in var.diagnostic_settings_storage_account :
-      alltrue([for m in v.metrics : m.category == null || contains(["Transaction", "AllMetrics"], m.category)])
+      alltrue([for m in v.metrics : m.category == null || contains(["Capacity", "Transaction", "AllMetrics"], m.category)])
     ])
-    error_message = "metrics[*].category must be 'Transaction', 'AllMetrics', or null."
+    error_message = "metrics[*].category must be 'Capacity', 'Transaction', 'AllMetrics', or null."
   }
 }
 


### PR DESCRIPTION
## Description

`Capacity` is a valid metric category for `Microsoft.Storage/storageAccounts`, but the module's own variable validation rejected it before the request ever reached Azure:

```
│ Metric categories must be 'Transaction' or 'AllMetrics'.
```

The validation on `var.diagnostic_settings_storage_account` only permitted `Transaction` and `AllMetrics`, so a legitimate configuration failed at plan time. This is purely a client-side validation gap — Azure was never contacted.

## Changes

- `variables.diagnostics.tf` — add `Capacity` to the allowed `metrics[*].category` values and update the error message.
- `variables.diagnostics.tf` — update the variable description (and regenerated `README.md`) to document `Capacity` as supported.
- `tests/unit/diagnostic_settings.tftest.hcl` — add two runs: one asserting `Capacity` is accepted and reaches the AzAPI request body unchanged, one asserting an unsupported category is still rejected.

Before:

```hcl
metrics = [{ category = "Capacity" }]  # rejected by the module at plan time
```

After: accepted, and sent to Azure as-is.

No behavioral change for existing configurations — this only widens an over-restrictive allow-list. The storage-account scope is deliberately left out of the `AllMetrics` normalization in `locals.diagnostics.tf`, since Azure returns `AllMetrics` unchanged at that scope; this PR does not alter that.

## Testing

`avm test unit` — all runs pass, including the two new ones. Verified the new `Capacity` test fails without the validation change, so it genuinely reproduces #322.

Note: `avm pr-check` could not complete locally because `tflint` ships no `windows-arm64` release; relying on CI for that step.

Fixes #322

Supersedes #325 — that PR predates the v0.7 AzAPI rewrite and targets the removed `metric_categories` interface. Thanks @jkarns87 for identifying the bug and proposing the original fix.

## Type of Change

- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #322" in the PR description.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] I did run all [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks