### PR TITLE
docs: note Key Vault RBAC ordering for customer-managed keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,8 @@ Description: Defines a customer managed key to use for encryption. Defaults to `
 - `user_assigned_identity` - (Optional) A user assigned identity used to access the key vault. Defaults to `null`, in which case the storage account's system-assigned identity is used.
   - `resource_id` - (Required) The full Azure Resource ID of the user assigned identity.
 
+The module does not create the Key Vault role assignment that permits the identity to use the key. Grant the identity `Key Vault Crypto Service Encryption User` on the vault before the storage account is created. Referencing the vault's resource ID does not make Terraform wait for that vault's role assignments to finish, so order the grant explicitly with `depends_on` on the module call. Alternatively, add a pattern such as `Forbidden` to `retry.error_message_regex` to retry while the assignment propagates.
+
 Example Inputs:
 ```terraform
 customer_managed_key = {

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,8 @@ Defines a customer managed key to use for encryption. Defaults to `null` (Micros
 - `user_assigned_identity` - (Optional) A user assigned identity used to access the key vault. Defaults to `null`, in which case the storage account's system-assigned identity is used.
   - `resource_id` - (Required) The full Azure Resource ID of the user assigned identity.
 
+The module does not create the Key Vault role assignment that permits the identity to use the key. Grant the identity `Key Vault Crypto Service Encryption User` on the vault before the storage account is created. Referencing the vault's resource ID does not make Terraform wait for that vault's role assignments to finish, so order the grant explicitly with `depends_on` on the module call. Alternatively, add a pattern such as `Forbidden` to `retry.error_message_regex` to retry while the assignment propagates.
+
 Example Inputs:
 ```terraform
 customer_managed_key = {


### PR DESCRIPTION
Documents an ordering requirement on the `customer_managed_key` input that the module cannot enforce itself.

The module does not create the Key Vault role assignment that lets the encryption identity use the key — the caller does. Passing `key_vault_resource_id` creates a dependency on the vault existing, not on its role assignments completing, so the CMK patch can fire before the grant has propagated and fail with a 403. The default `retry.error_message_regex` deliberately excludes 403 so authorization failures stay visible, which means this surfaces as a hard failure.

The note covers both the `depends_on` fix and the `retry` alternative.

Raised in #364, where the reporter hit this and attributed it to the two-step `azapi_update_resource` CMK apply. That two-step is unrelated and still required: when `user_assigned_identity` is `null` the account's system-assigned identity is used, and that identity has no principal ID until the account exists.

Docs only. `README.md` regenerated with `avm docs`.