### PR TITLE
Fix race condition between containers and blob

### DIFF
--- a/main.containers.tf
+++ b/main.containers.tf
@@ -17,4 +17,6 @@ module "containers" {
   role_assignments                          = each.value.role_assignments
   timeouts                                  = each.value.timeouts != null ? each.value.timeouts : var.timeouts
   tracing_tags_header                       = var.enable_telemetry ? local.avm_azapi_header : null
+
+  depends_on = [module.blob_service]
 }


### PR DESCRIPTION
## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

main.containers.tf — the containers submodule depends only on azapi_resource.this.id (the storage account itself). main.blob_service.tf — the blob_service submodule (which owns restore_policy, i.e. Point-in-Time Restore) also depends only on azapi_resource.this.id.

Since containers cannot be deployed with immutability, restore_policy must be disabled. However, if it was enabled at any point, terraform apply will fail because of this race condition.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [X] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [X] My corresponding pipelines / checks run clean and green without any errors or warnings
- [X] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
