### PR TITLE
fix: order containers after blob service (#392)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Description: A map of containers to create on the storage account. The map key i
 - `deny_encryption_scope_override` - (Optional) When set to `true`, blocks blob uploads from specifying a different encryption scope. Defaults to `null`.
 - `enable_nfs_v3_all_squash` - (Optional) Enable NFSv3 all squash (only valid for NFSv3 enabled accounts). Defaults to `null`.
 - `enable_nfs_v3_root_squash` - (Optional) Enable NFSv3 root squash (only valid for NFSv3 enabled accounts). Defaults to `null`.
-- `immutable_storage_with_versioning` - (Optional) Configures container-level immutability with version-level WORM. Defaults to `null`. Supports:
+- `immutable_storage_with_versioning` - (Optional) Configures container-level immutability with version-level WORM. Defaults to `null`. Cannot be used together with `blob_properties.restore_policy`: Azure does not support point-in-time restore on an account that has version-level immutability on any container. Supports:
   - `enabled` - (Required) Whether immutable storage with versioning is enabled.
 - `role_assignments` - (Optional) A map of role assignments to create on the container. Defaults to `{}`. See `var.role_assignments` for the attribute schema.
 - `timeouts` - (Optional) Per-operation timeouts for the container resource. Defaults to `null` (uses provider defaults inherited from `var.timeouts`). Supports:

--- a/main.containers.tf
+++ b/main.containers.tf
@@ -18,5 +18,7 @@ module "containers" {
   timeouts                                  = each.value.timeouts != null ? each.value.timeouts : var.timeouts
   tracing_tags_header                       = var.enable_telemetry ? local.avm_azapi_header : null
 
+  # Azure rejects version-level immutability on a container while point-in-time
+  # restore is enabled on the blob service, so blob properties must settle first.
   depends_on = [module.blob_service]
 }

--- a/main.containers.tf
+++ b/main.containers.tf
@@ -17,4 +17,6 @@ module "containers" {
   role_assignments                          = each.value.role_assignments
   timeouts                                  = each.value.timeouts != null ? each.value.timeouts : var.timeouts
   tracing_tags_header                       = var.enable_telemetry ? local.avm_azapi_header : null
+
+  depends_on = [module.blob_service]
 }

--- a/variables.container.tf
+++ b/variables.container.tf
@@ -40,7 +40,7 @@ A map of containers to create on the storage account. The map key is arbitrary; 
 - `deny_encryption_scope_override` - (Optional) When set to `true`, blocks blob uploads from specifying a different encryption scope. Defaults to `null`.
 - `enable_nfs_v3_all_squash` - (Optional) Enable NFSv3 all squash (only valid for NFSv3 enabled accounts). Defaults to `null`.
 - `enable_nfs_v3_root_squash` - (Optional) Enable NFSv3 root squash (only valid for NFSv3 enabled accounts). Defaults to `null`.
-- `immutable_storage_with_versioning` - (Optional) Configures container-level immutability with version-level WORM. Defaults to `null`. Supports:
+- `immutable_storage_with_versioning` - (Optional) Configures container-level immutability with version-level WORM. Defaults to `null`. Cannot be used together with `blob_properties.restore_policy`: Azure does not support point-in-time restore on an account that has version-level immutability on any container. Supports:
   - `enabled` - (Required) Whether immutable storage with versioning is enabled.
 - `role_assignments` - (Optional) A map of role assignments to create on the container. Defaults to `{}`. See `var.role_assignments` for the attribute schema.
 - `timeouts` - (Optional) Per-operation timeouts for the container resource. Defaults to `null` (uses provider defaults inherited from `var.timeouts`). Supports:


### PR DESCRIPTION
Release branch for #392 (@captainhook) — orders the containers submodule after the blob service.

`module.containers` and `module.blob_service` both depended only on `azapi_resource.this`, so Terraform ran them in parallel. The blob service carries `restorePolicy` (point-in-time restore) and containers carry `immutableStorageWithVersioning`, which Azure treats as mutually exclusive — [PITR isn't supported when version-level immutability is enabled on the account or any container](https://learn.microsoft.com/azure/storage/blobs/point-in-time-restore-overview#limitations-and-known-issues). An apply that disables `restore_policy` while adding an immutable container therefore failed whenever the container write won the race.

`depends_on = [module.blob_service]` makes blob properties settle first. `terraform graph` before → after:

```
before:  module.containers.azapi_resource.this -> azapi_resource.this
after:   module.containers.azapi_resource.this -> module.blob_service.azapi_update_resource.this
```

No-op when `blob_properties` is null (`module.blob_service` has `count = 0`). On destroy the order reverses, so containers are removed before blob service changes.

Also adds a comment recording why the dependency exists, and documents the constraint on `containers.immutable_storage_with_versioning`.

Routed through a release branch so e2e can run — #392 was from a fork, where `pr-check.yml` skips the managed workflow.

The race only fires on a transition (PITR previously enabled, then disabled in the same apply that adds an immutable container), which a single-stage apply/plan/destroy run can't reproduce. Green e2e here shows no regression rather than proof of the fix; the evidence is the graph edge above.