### PR TITLE
fix: order static website after blob service

### DIFF
--- a/examples/static_website/README.md
+++ b/examples/static_website/README.md
@@ -6,6 +6,8 @@ Enables static website hosting on a StorageV2 account and creates the reserved `
 
 Static website hosting is configured through the `properties.staticWebsite` block on the `blobServices/default` sub-resource, which requires API version `2025-08-01` or later.
 
+Blob service properties are set alongside it because they target that same sub-resource, so this example exercises both writers in a single apply.
+
 ```hcl
 terraform {
   required_version = ">= 1.10.0"
@@ -54,6 +56,15 @@ module "this" {
   location  = azapi_resource.resource_group.location
   name      = module.naming.storage_account.name_unique
   parent_id = azapi_resource.resource_group.id
+  # Written to the same blobServices/default object as the static website config,
+  # so this example covers both writers in one apply.
+  blob_properties = {
+    versioning_enabled = true
+    delete_retention_policy = {
+      enabled = true
+      days    = 7
+    }
+  }
   # Azure Storage serves the static site from the reserved $web container.
   containers = {
     web = {

--- a/examples/static_website/_header.md
+++ b/examples/static_website/_header.md
@@ -3,3 +3,5 @@
 Enables static website hosting on a StorageV2 account and creates the reserved `$web` container that Azure Storage serves the site from.
 
 Static website hosting is configured through the `properties.staticWebsite` block on the `blobServices/default` sub-resource, which requires API version `2025-08-01` or later.
+
+Blob service properties are set alongside it because they target that same sub-resource, so this example exercises both writers in a single apply.

--- a/examples/static_website/main.tf
+++ b/examples/static_website/main.tf
@@ -45,6 +45,15 @@ module "this" {
   location  = azapi_resource.resource_group.location
   name      = module.naming.storage_account.name_unique
   parent_id = azapi_resource.resource_group.id
+  # Written to the same blobServices/default object as the static website config,
+  # so this example covers both writers in one apply.
+  blob_properties = {
+    versioning_enabled = true
+    delete_retention_policy = {
+      enabled = true
+      days    = 7
+    }
+  }
   # Azure Storage serves the static site from the reserved $web container.
   containers = {
     web = {

--- a/main.static_website.tf
+++ b/main.static_website.tf
@@ -11,4 +11,9 @@ module "static_website" {
   retry               = var.retry
   timeouts            = var.timeouts
   tracing_tags_header = var.enable_telemetry ? local.avm_azapi_header : null
+
+  # This submodule and blob_service patch the same blobServices/default object, and
+  # azapi_update_resource is GET + client-side merge + PUT, so concurrent writes
+  # would each overwrite the other's fields. Keep this ordering.
+  depends_on = [module.blob_service]
 }

--- a/tests/unit/static_website.tftest.hcl
+++ b/tests/unit/static_website.tftest.hcl
@@ -39,6 +39,24 @@ run "static_website_module_instantiated" {
   }
 }
 
+# Regression cover for #396: the root module orders static_website after
+# blob_service because both write blobServices/default. A cycle introduced by that
+# ordering fails here at graph construction, which `terraform validate` misses.
+run "static_website_coexists_with_blob_properties" {
+  command = plan
+
+  variables {
+    blob_properties = {
+      versioning_enabled = true
+    }
+  }
+
+  assert {
+    condition     = length(module.static_website) == 1 && length(module.blob_service) == 1
+    error_message = "Expected the static_website and blob_service submodules to coexist"
+  }
+}
+
 run "static_website_omitted_when_null" {
   command = plan
 


### PR DESCRIPTION
Closes #396.

`module.static_website` and `module.blob_service` both write `<account>/blobServices/default`, and both depended only on `azapi_resource.this`, so Terraform applied them concurrently.

`azapi_update_resource` is not a server-side patch: [`CreateUpdate`](https://github.com/Azure/terraform-provider-azapi/blob/main/internal/services/azapi_update_resource.go) does `client.Get` → `MergeObjectWithOption` → `client.CreateOrUpdate`, with no `If-Match`. Two concurrent instances therefore read the same pre-update body, each merge only their own fields, and the later write drops the other's — a lost update rather than an ARM 409, so Azure gets no opportunity to reject it. Drift surfaces on a later plan rather than as an apply error.

`depends_on = [module.blob_service]` makes the static-website write read a body that already contains the blob properties. Direction matters beyond consistency with #395: `resource_types.blob_service` defaults to `2025-06-01`, which predates `properties.staticWebsite` in the schema (#389), so the blob service cannot preserve a static-website config it reads. Ordering it first means it writes before `staticWebsite` exists and the static-website submodule reasserts it afterwards. No-op when `blob_properties` is null (`count = 0`).

```
before:  module.static_website.azapi_update_resource.this -> azapi_resource.this
after:   module.static_website.azapi_update_resource.this -> module.blob_service.azapi_update_resource.this
```

## Coverage

No example set both inputs, so this path had never run in CI. `examples/static_website` now also sets `blob_properties`; module defaults and consumer configurations are unchanged. The e2e idempotency plan only catches a dropped field when the race lands unfavourably, so it buys regression cover of the combined path rather than proof — the evidence for the fix is the graph edge above.

The added unit test cannot prove ordering either. Its value is that a `depends_on` cycle fails at graph construction during `plan`, which `terraform validate` does not catch.